### PR TITLE
Add lint rules

### DIFF
--- a/chai.js
+++ b/chai.js
@@ -3,4 +3,4 @@ module.exports = {
     // disallow usage of expressions in statement position
     'no-unused-expressions': 0
   }
-};
+}

--- a/chai.js
+++ b/chai.js
@@ -1,3 +1,6 @@
 module.exports = {
-  rules: {}
+  rules: {
+    // disallow usage of expressions in statement position
+    'no-unused-expressions': 0
+  }
 };

--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ module.exports = {
     'no-irregular-whitespace': 1,
     // disallow negation of the left operand of an in expression
     'no-negated-in-lhs': 1,
-    // disallow the use of object properties of the global object (Math and JSON) as functions
+    // disallow the use of object properties of the global object (Math and
+    // JSON) as functions
     'no-obj-calls': 1,
     // disallow multiple spaces in a regular expression literal
     'no-regex-spaces': 1,
@@ -62,7 +63,8 @@ module.exports = {
     'no-sparse-arrays': 1,
     // Avoid code that looks like two expressions but is actually one
     'no-unexpected-multiline': 1,
-    // disallow unreachable statements after a return, throw, continue, or break statement
+    // disallow unreachable statements after a return, throw, continue, or
+    // break statement
     'no-unreachable': 1,
     // disallow comparisons with the value NaN
     'use-isnan': 1,
@@ -118,7 +120,8 @@ module.exports = {
     'no-extra-bind': 1,
     // disallow fallthrough of case statements
     'no-fallthrough': 1,
-    // disallow the use of leading or trailing decimal points in numeric literals
+    // disallow the use of leading or trailing decimal points in numeric
+    // literals
     'no-floating-decimal': 1,
     // disallow the type conversions with shorter notations
     'no-implicit-coercion': 1,
@@ -146,9 +149,11 @@ module.exports = {
     'no-new-func': 1,
     // disallows creating new instances of String,Number, and Boolean
     'no-new-wrappers': 1,
-    // disallow use of the new operator when not part of an assignment or comparison
+    // disallow use of the new operator when not part of an assignment or
+    // comparison
     'no-new': 1,
-    // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
+    // disallow use of octal escape sequences in string literals, such as var
+    // foo = "Copyright \251";
     'no-octal-escape': 1,
     // disallow use of octal literals
     'no-octal': 1,
@@ -178,7 +183,8 @@ module.exports = {
     'no-useless-concat': 1,
     // disallow use of the void operator
     'no-void': 1,
-    // disallow usage of configurable warning terms in comments - e.g. TODO or FIXME
+    // disallow usage of configurable warning terms in comments - e.g. TODO
+    // or FIXME
     'no-warning-comments': 1,
     // disallow use of the with statement
     'no-with': 1,
@@ -202,7 +208,8 @@ module.exports = {
     //
     // enforce or disallow variable initializations at definition
     'init-declarations': 1,
-    // disallow the catch clause parameter name being the same as a variable in the outer scope
+    // disallow the catch clause parameter name being the same as a variable in
+    // the outer scope
     'no-catch-shadow': 1,
     // disallow deletion of variables
     'no-delete-var': 1,
@@ -214,7 +221,8 @@ module.exports = {
     'no-shadow': 1,
     // disallow use of undefined when initializing variables
     'no-undef-init': 1,
-    // disallow use of undeclared variables unless mentioned in a /*global */ block
+    // disallow use of undeclared variables unless mentioned in a /*global */
+    // block
     'no-undef': 1,
     // disallow use of undefined variable
     'no-undefined': 0,
@@ -270,7 +278,8 @@ module.exports = {
     'func-names': 1,
     // enforce use of function declarations or expressions
     'func-style': [1, 'declaration', { allowArrowFunctions: true }],
-    // this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
+    // this option enforces minimum and maximum identifier lengths (variable
+    // names, property names etc.)
     'id-length': 0,
     // require identifiers to match the provided regular expression
     'id-match': 0,
@@ -290,13 +299,15 @@ module.exports = {
     'max-len': [1, 80, 2],
     // specify the maximum depth callbacks can be nested
     'max-nested-callbacks': [1, 3],
-    // limits the number of parameters that can be used in the function declaration.
+    // limits the number of parameters that can be used in the function
+    // declaration.
     'max-params': [1, 3],
     // specify the maximum number of statement allowed in a function
     'max-statements': 1,
     // require a capital letter for constructors
     'new-cap': 1,
-    // disallow the omission of parentheses when invoking a constructor with no arguments
+    // disallow the omission of parentheses when invoking a constructor with no
+    // arguments
     'new-parens': 1,
     // require or disallow an empty newline after variable declarations
     'newline-after-var': 1,
@@ -338,7 +349,8 @@ module.exports = {
     'object-curly-spacing': [1, 'always'],
     // require or disallow one variable declaration per function
     'one-var': [1, 'never'],
-    // require assignment operator shorthand where possible or prohibit it entirely
+    // require assignment operator shorthand where possible or prohibit it
+    // entirely
     'operator-assignment': [1, 'always'],
     // enforce operators to be placed before or after line breaks
     'operator-linebreak': 1,
@@ -372,7 +384,8 @@ module.exports = {
     'space-return-throw-case': 1,
     // require or disallow spaces before/after unary operators
     'space-unary-ops': 1,
-    // require or disallow a space immediately following the // or /* in a comment
+    // require or disallow a space immediately following the // or /* in a
+    // comment
     'spaced-comment': 1,
     // require regex literals to be wrapped in parentheses
     'wrap-regex': 1,
@@ -406,7 +419,8 @@ module.exports = {
     'object-shorthand': 1,
     // suggest using arrow functions as callbacks
     'prefer-arrow-callback': 1,
-    // suggest using const declaration for variables that are never modified after declared
+    // suggest using const declaration for variables that are never modified
+    // after declared
     'prefer-const': 1,
     // suggest using Reflect methods where applicable
     'prefer-reflect': 0,

--- a/index.js
+++ b/index.js
@@ -195,6 +195,32 @@ module.exports = {
     // Strict Mode
     //
     // controls location of Use Strict Directives
-    'strict': [1, 'never']
+    'strict': [1, 'never'],
+
+    //
+    // Variables
+    //
+    // enforce or disallow variable initializations at definition
+    'init-declarations': 1,
+    // disallow the catch clause parameter name being the same as a variable in the outer scope
+    'no-catch-shadow': 1,
+    // disallow deletion of variables
+    'no-delete-var': 1,
+    // disallow labels that share a name with a variable
+    'no-label-var': 1,
+    // disallow shadowing of names such as arguments
+    'no-shadow-restricted-names': 1,
+    // disallow declaration of variables already declared in the outer scope
+    'no-shadow': 1,
+    // disallow use of undefined when initializing variables
+    'no-undef-init': 1,
+    // disallow use of undeclared variables unless mentioned in a /*global */ block
+    'no-undef': 1,
+    // disallow use of undefined variable
+    'no-undefined': 0,
+    // disallow declaration of variables that are not used in the code
+    'no-unused-vars': 1,
+    // disallow use of variables before they are defined
+    'no-use-before-define': [1, 'nofunc']
   }
 };

--- a/index.js
+++ b/index.js
@@ -417,4 +417,4 @@ module.exports = {
     // disallow generator functions that do not have yield
     'require-yield': 1
   }
-};
+}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   parser: 'babel-eslint',
   env: {
+    browser: true,
     node: true,
     es6: true
   },

--- a/index.js
+++ b/index.js
@@ -189,6 +189,12 @@ module.exports = {
     // require immediate function invocation to be wrapped in parentheses
     'wrap-iife': 1,
     // require or disallow Yoda conditions
-    'yoda': 1
+    'yoda': 1,
+
+    //
+    // Strict Mode
+    //
+    // controls location of Use Strict Directives
+    'strict': [1, 'never']
   }
 };

--- a/index.js
+++ b/index.js
@@ -10,5 +10,65 @@ module.exports = {
   },
 
   globals: {},
-  rules: {}
+  rules: {
+    //
+    // Possible Errors
+    //
+    // disallow or enforce trailing commas
+    'comma-dangle': 1,
+    // disallow assignment in conditional expressions
+    'no-cond-assign': 1,
+    // disallow use of console in the node environment
+    'no-console': 1,
+    // disallow use of constant expressions in conditions
+    'no-constant-condition': 1,
+    // disallow control characters in regular expressions
+    'no-control-regex': 1,
+    // disallow use of debugger
+    'no-debugger': 1,
+    // disallow duplicate arguments in functions
+    'no-dupe-args': 1,
+    // disallow duplicate keys when creating object literals
+    'no-dupe-keys': 1,
+    // disallow a duplicate case label.
+    'no-duplicate-case': 1,
+    // disallow the use of empty character classes in regular expressions
+    'no-empty-character-class': 1,
+    // disallow empty statements
+    'no-empty': 1,
+    // disallow assigning to the exception in a catch block
+    'no-ex-assign': 1,
+    // disallow double-negation boolean casts in a boolean context
+    'no-extra-boolean-cast': 1,
+    // disallow unnecessary parentheses
+    'no-extra-parens': 1,
+    // disallow unnecessary semicolons
+    'no-extra-semi': 1,
+    // disallow overwriting functions written as function declarations
+    'no-func-assign': 1,
+    // disallow function or variable declarations in nested blocks
+    'no-inner-declarations': [1, 'both'],
+    // disallow invalid regular expression strings in the RegExp constructor
+    'no-invalid-regexp': 1,
+    // disallow irregular whitespace outside of strings and comments
+    'no-irregular-whitespace': 1,
+    // disallow negation of the left operand of an in expression
+    'no-negated-in-lhs': 1,
+    // disallow the use of object properties of the global object (Math and JSON) as functions
+    'no-obj-calls': 1,
+    // disallow multiple spaces in a regular expression literal
+    'no-regex-spaces': 1,
+    // disallow sparse arrays
+    'no-sparse-arrays': 1,
+    // Avoid code that looks like two expressions but is actually one
+    'no-unexpected-multiline': 1,
+    // disallow unreachable statements after a return, throw, continue, or break statement
+    'no-unreachable': 1,
+    // disallow comparisons with the value NaN
+    'use-isnan': 1,
+    // Ensure JSDoc comments are valid
+    'valid-jsdoc': 1,
+    // Ensure that the results of typeof are compared against a valid string
+    'valid-typeof': 1,
+  }
 };

--- a/index.js
+++ b/index.js
@@ -70,5 +70,125 @@ module.exports = {
     'valid-jsdoc': 1,
     // Ensure that the results of typeof are compared against a valid string
     'valid-typeof': 1,
+
+    //
+    // Best Practices
+    //
+    // Enforces getter/setter pairs in objects
+    'accessor-pairs': 1,
+    // treat var statements as if they were block scoped
+    'block-scoped-var': 1,
+    // specify the maximum cyclomatic complexity allowed in a program
+    'complexity': [1, 2],
+    // require return statements to either always or never specify values
+    'consistent-return': 1,
+    // specify curly brace conventions for all control statements
+    'curly': [1, 'multi-line'],
+    // require default case in switch statements
+    'default-case': 1,
+    // enforces consistent newlines before or after dots
+    'dot-location': [1, 'property'],
+    // encourages use of dot notation whenever possible
+    'dot-notation': 1,
+    // require the use of === and !==
+    'eqeqeq': 1,
+    // make sure for-in loops have an if statement
+    'guard-for-in': 1,
+    // disallow the use of alert, confirm, and prompt
+    'no-alert': 1,
+    // disallow use of arguments.caller or arguments.callee
+    'no-caller': 1,
+    // disallow lexical declarations in case clauses
+    'no-case-declarations': 1,
+    // disallow division operators explicitly at beginning of regular expression
+    'no-div-regex': 1,
+    // disallow else after a return in an if
+    'no-else-return': 1,
+    // disallow use of labels for anything other than loops and switches
+    'no-empty-label': 1,
+    // disallow use of empty destructuring patterns
+    'no-empty-pattern': 1,
+    // disallow comparisons to null without a type-checking operator
+    'no-eq-null': 1,
+    // disallow use of eval()
+    'no-eval': 1,
+    // disallow adding to native types
+    'no-extend-native': 1,
+    // disallow unnecessary function binding
+    'no-extra-bind': 1,
+    // disallow fallthrough of case statements
+    'no-fallthrough': 1,
+    // disallow the use of leading or trailing decimal points in numeric literals
+    'no-floating-decimal': 1,
+    // disallow the type conversions with shorter notations
+    'no-implicit-coercion': 1,
+    // disallow use of eval()-like methods
+    'no-implied-eval': 1,
+    // disallow this keywords outside of classes or class-like objects
+    'no-invalid-this': 1,
+    // disallow usage of __iterator__ property
+    'no-iterator': 1,
+    // disallow use of labeled statements
+    'no-labels': 1,
+    // disallow unnecessary nested blocks
+    'no-lone-blocks': 1,
+    // disallow creation of functions within loops
+    'no-loop-func': 1,
+    // disallow the use of magic numbers
+    'no-magic-numbers': 0,
+    // disallow use of multiple spaces
+    'no-multi-spaces': 1,
+    // disallow use of multiline strings
+    'no-multi-str': 1,
+    // disallow reassignments of native objects
+    'no-native-reassign': 1,
+    // disallow use of new operator for Function object
+    'no-new-func': 1,
+    // disallows creating new instances of String,Number, and Boolean
+    'no-new-wrappers': 1,
+    // disallow use of the new operator when not part of an assignment or comparison
+    'no-new': 1,
+    // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
+    'no-octal-escape': 1,
+    // disallow use of octal literals
+    'no-octal': 1,
+    // disallow reassignment of function parameters
+    'no-param-reassign': 1,
+    // disallow use of process.env
+    'no-process-env': 1,
+    // disallow usage of __proto__ property
+    'no-proto': 1,
+    // disallow declaring the same variable more than once
+    'no-redeclare': 1,
+    // disallow use of assignment in return statement
+    'no-return-assign': 1,
+    // disallow use of javascript: urls.
+    'no-script-url': 1,
+    // disallow comparisons where both sides are exactly the same
+    'no-self-compare': 1,
+    // disallow use of the comma operator
+    'no-sequences': 1,
+    // restrict what can be thrown as an exception
+    'no-throw-literal': 1,
+    // disallow usage of expressions in statement position
+    'no-unused-expressions': 1,
+    // disallow unnecessary .call() and .apply()
+    'no-useless-call': 1,
+    // disallow unnecessary concatenation of literals or template literals
+    'no-useless-concat': 1,
+    // disallow use of the void operator
+    'no-void': 1,
+    // disallow usage of configurable warning terms in comments - e.g. TODO or FIXME
+    'no-warning-comments': 1,
+    // disallow use of the with statement
+    'no-with': 1,
+    // require use of the second argument for parseInt()
+    'radix': 1,
+    // require declaration of all vars at the top of their containing scope
+    'vars-on-top': 1,
+    // require immediate function invocation to be wrapped in parentheses
+    'wrap-iife': 1,
+    // require or disallow Yoda conditions
+    'yoda': 1
   }
 };

--- a/index.js
+++ b/index.js
@@ -221,6 +221,28 @@ module.exports = {
     // disallow declaration of variables that are not used in the code
     'no-unused-vars': 1,
     // disallow use of variables before they are defined
-    'no-use-before-define': [1, 'nofunc']
+    'no-use-before-define': [1, 'nofunc'],
+
+    //
+    // Node.js and CommonJS
+    //
+    // enforce return after a callback
+    'callback-return': 1,
+    // enforce require() on top-level module scope
+    'global-require': 1,
+    // enforce error handling in callbacks
+    'handle-callback-err': 1,
+    // disallow mixing regular variable and require declarations
+    'no-mixed-requires': 1,
+    // disallow use of new operator with the require function
+    'no-new-require': 1,
+    // disallow string concatenation with __dirname and __filename
+    'no-path-concat': 1,
+    // disallow process.exit()
+    'no-process-exit': 1,
+    // restrict usage of specified node modules
+    'no-restricted-modules': 0,
+    // disallow use of synchronous methods
+    'no-sync': 1
   }
 };

--- a/index.js
+++ b/index.js
@@ -243,6 +243,46 @@ module.exports = {
     // restrict usage of specified node modules
     'no-restricted-modules': 0,
     // disallow use of synchronous methods
-    'no-sync': 1
+    'no-sync': 1,
+
+    //
+    // ECMAScript 6
+    //
+    // require braces in arrow function body
+    'arrow-body-style': 1,
+    // require parens in arrow function arguments
+    'arrow-parens': [1, 'as-needed'],
+    // require space before/after arrow function's arrow
+    'arrow-spacing': 1,
+    // verify calls of super() in constructors
+    'constructor-super': 1,
+    // enforce spacing around the * in generator functions
+    'generator-star-spacing': [1, 'after'],
+    // disallow arrow functions where a condition is expected
+    'no-arrow-condition': 0,
+    // disallow modifying variables of class declarations
+    'no-class-assign': 1,
+    // disallow modifying variables that are declared using const
+    'no-const-assign': 1,
+    // disallow duplicate name in class members
+    'no-dupe-class-members': 1,
+    // disallow use of this/super before calling super() in constructors.
+    'no-this-before-super': 1,
+    // require let or const instead of var
+    'no-var': 1,
+    // require method and property shorthand syntax for object literals
+    'object-shorthand': 1,
+    // suggest using arrow functions as callbacks
+    'prefer-arrow-callback': 1,
+    // suggest using const declaration for variables that are never modified after declared
+    'prefer-const': 1,
+    // suggest using Reflect methods where applicable
+    'prefer-reflect': 0,
+    // suggest using the spread operator instead of .apply().
+    'prefer-spread': 1,
+    // suggest using template literals instead of strings concatenation
+    'prefer-template': 1,
+    // disallow generator functions that do not have yield
+    'require-yield': 1
   }
 };

--- a/index.js
+++ b/index.js
@@ -79,11 +79,11 @@ module.exports = {
     // treat var statements as if they were block scoped
     'block-scoped-var': 1,
     // specify the maximum cyclomatic complexity allowed in a program
-    'complexity': [1, 2],
+    complexity: [1, 2],
     // require return statements to either always or never specify values
     'consistent-return': 1,
     // specify curly brace conventions for all control statements
-    'curly': [1, 'multi-line'],
+    curly: [1, 'multi-line'],
     // require default case in switch statements
     'default-case': 1,
     // enforces consistent newlines before or after dots
@@ -91,7 +91,7 @@ module.exports = {
     // encourages use of dot notation whenever possible
     'dot-notation': 1,
     // require the use of === and !==
-    'eqeqeq': 1,
+    eqeqeq: 1,
     // make sure for-in loops have an if statement
     'guard-for-in': 1,
     // disallow the use of alert, confirm, and prompt
@@ -183,19 +183,19 @@ module.exports = {
     // disallow use of the with statement
     'no-with': 1,
     // require use of the second argument for parseInt()
-    'radix': 1,
+    radix: 1,
     // require declaration of all vars at the top of their containing scope
     'vars-on-top': 1,
     // require immediate function invocation to be wrapped in parentheses
     'wrap-iife': 1,
     // require or disallow Yoda conditions
-    'yoda': 1,
+    yoda: 1,
 
     //
     // Strict Mode
     //
     // controls location of Use Strict Directives
-    'strict': [1, 'never'],
+    strict: [1, 'never'],
 
     //
     // Variables
@@ -244,6 +244,138 @@ module.exports = {
     'no-restricted-modules': 0,
     // disallow use of synchronous methods
     'no-sync': 1,
+
+    //
+    // Stylistic Issues
+    //
+    // enforce spacing inside array brackets
+    'array-bracket-spacing': 1,
+    // disallow or enforce spaces inside of single line blocks
+    'block-spacing': 1,
+    // enforce one true brace style
+    'brace-style': 1,
+    // require camel case names
+    camelcase: [1, { properties: 'never' }],
+    // enforce spacing before and after comma
+    'comma-spacing': 1,
+    // enforce one true comma style
+    'comma-style': 1,
+    // require or disallow padding inside computed properties
+    'computed-property-spacing': 1,
+    // enforce consistent naming when capturing the current execution context
+    'consistent-this': [1, 'self'],
+    // enforce newline at the end of file, with no multiple empty lines
+    'eol-last': 1,
+    // require function expressions to have a name
+    'func-names': 1,
+    // enforce use of function declarations or expressions
+    'func-style': [1, 'declaration', { allowArrowFunctions: true }],
+    // this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
+    'id-length': 1,
+    // require identifiers to match the provided regular expression
+    'id-match': 0,
+    // specify tab or space width for your code
+    indent: [1, 2, { SwitchCase: 1 }],
+    // specify whether double or single quotes should be used in JSX attributes
+    'jsx-quotes': [1, 'prefer-single'],
+    // enforce spacing between keys and values in object literal properties
+    'key-spacing': 1,
+    // disallow mixed 'LF' and 'CRLF' as linebreaks
+    'linebreak-style': 1,
+    // enforce empty lines around comments
+    'lines-around-comment': 1,
+    // specify the maximum depth that blocks can be nested
+    'max-depth': 1,
+    // specify the maximum length of a line in your program
+    'max-len': [2, 80, 2],
+    // specify the maximum depth callbacks can be nested
+    'max-nested-callbacks': [1, 3],
+    // limits the number of parameters that can be used in the function declaration.
+    'max-params': [1, 3],
+    // specify the maximum number of statement allowed in a function
+    'max-statements': 1,
+    // require a capital letter for constructors
+    'new-cap': 1,
+    // disallow the omission of parentheses when invoking a constructor with no arguments
+    'new-parens': 1,
+    // require or disallow an empty newline after variable declarations
+    'newline-after-var': 1,
+    // disallow use of the Array constructor
+    'no-array-constructor': 1,
+    // disallow use of bitwise operators
+    'no-bitwise': 1,
+    // disallow use of the continue statement
+    'no-continue': 1,
+    // disallow comments inline after code
+    'no-inline-comments': 1,
+    // disallow if as the only statement in an else block
+    'no-lonely-if': 1,
+    // disallow mixed spaces and tabs for indentation
+    'no-mixed-spaces-and-tabs': 1,
+    // disallow multiple empty lines
+    'no-multiple-empty-lines': [1, { max: 1 }],
+    // disallow negated conditions
+    'no-negated-condition': 1,
+    // disallow nested ternary expressions
+    'no-nested-ternary': 1,
+    // disallow the use of the Object constructor
+    'no-new-object': 1,
+    // disallow use of unary operators, ++ and --
+    'no-plusplus': 1,
+    // disallow use of certain syntax in code
+    'no-restricted-syntax': 0,
+    // disallow space between function identifier and application
+    'no-spaced-func': 1,
+    // disallow the use of ternary operators
+    'no-ternary': 0,
+    // disallow trailing whitespace at the end of lines
+    'no-trailing-spaces': 1,
+    // disallow dangling underscores in identifiers
+    'no-underscore-dangle': 1,
+    // disallow the use of ternary operators when a simpler alternative exists
+    'no-unneeded-ternary': 1,
+    // require or disallow padding inside curly braces
+    'object-curly-spacing': [1, 'always'],
+    // require or disallow one variable declaration per function
+    'one-var': [1, 'never'],
+    // require assignment operator shorthand where possible or prohibit it entirely
+    'operator-assignment': [1, 'always'],
+    // enforce operators to be placed before or after line breaks
+    'operator-linebreak': 1,
+    // enforce padding within blocks
+    'padded-blocks': [1, 'never'],
+    // require quotes around object literal property names
+    'quote-props': [1, 'as-needed'],
+    // specify whether backticks, double or single quotes should be used
+    quotes: [1, 'single', 'avoid-escape'],
+    // Require JSDoc comment
+    'require-jsdoc': 0,
+    // enforce spacing before and after semicolons
+    'semi-spacing': 1,
+    // require or disallow use of semicolons instead of ASI
+    semi: [1, 'never'],
+    // sort variables within the same declaration block
+    'sort-vars': 0,
+    // require a space after certain keywords
+    'space-after-keywords': 1,
+    // require or disallow a space before blocks
+    'space-before-blocks': 1,
+    // require or disallow a space before function opening parenthesis
+    'space-before-function-paren': [1, 'never'],
+    // require a space before certain keywords
+    'space-before-keywords': 1,
+    // require or disallow spaces inside parentheses
+    'space-in-parens': 1,
+    // require spaces around operators
+    'space-infix-ops': 1,
+    // require a space after return, throw, and case
+    'space-return-throw-case': 1,
+    // require or disallow spaces before/after unary operators
+    'space-unary-ops': 1,
+    // require or disallow a space immediately following the // or /* in a comment
+    'spaced-comment': 1,
+    // require regex literals to be wrapped in parentheses
+    'wrap-regex': 1,
 
     //
     // ECMAScript 6

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = {
     // disallow double-negation boolean casts in a boolean context
     'no-extra-boolean-cast': 1,
     // disallow unnecessary parentheses
-    'no-extra-parens': 1,
+    'no-extra-parens': [1, 'functions'],
     // disallow unnecessary semicolons
     'no-extra-semi': 1,
     // disallow overwriting functions written as function declarations

--- a/index.js
+++ b/index.js
@@ -255,7 +255,7 @@ module.exports = {
     // enforce one true brace style
     'brace-style': 1,
     // require camel case names
-    camelcase: [1, { properties: 'never' }],
+    camelcase: 1,
     // enforce spacing before and after comma
     'comma-spacing': 1,
     // enforce one true comma style
@@ -271,7 +271,7 @@ module.exports = {
     // enforce use of function declarations or expressions
     'func-style': [1, 'declaration', { allowArrowFunctions: true }],
     // this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
-    'id-length': 1,
+    'id-length': 0,
     // require identifiers to match the provided regular expression
     'id-match': 0,
     // specify tab or space width for your code
@@ -287,7 +287,7 @@ module.exports = {
     // specify the maximum depth that blocks can be nested
     'max-depth': 1,
     // specify the maximum length of a line in your program
-    'max-len': [2, 80, 2],
+    'max-len': [1, 80, 2],
     // specify the maximum depth callbacks can be nested
     'max-nested-callbacks': [1, 3],
     // limits the number of parameters that can be used in the function declaration.
@@ -307,7 +307,7 @@ module.exports = {
     // disallow use of the continue statement
     'no-continue': 1,
     // disallow comments inline after code
-    'no-inline-comments': 1,
+    'no-inline-comments': 0,
     // disallow if as the only statement in an else block
     'no-lonely-if': 1,
     // disallow mixed spaces and tabs for indentation

--- a/mocha.js
+++ b/mocha.js
@@ -3,5 +3,8 @@ module.exports = {
     mocha: true
   },
 
-  rules: {}
+  rules: {
+    // specify the maximum depth callbacks can be nested
+    'max-nested-callbacks': 0
+  }
 };

--- a/mocha.js
+++ b/mocha.js
@@ -7,4 +7,4 @@ module.exports = {
     // specify the maximum depth callbacks can be nested
     'max-nested-callbacks': 0
   }
-};
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-zeal",
   "description": "ESLint sharable configuration matching Zeal's style guide",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "main": "index.js",
   "scripts": {
     "test": "eslint ."

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-zeal",
   "description": "ESLint sharable configuration matching Zeal's style guide",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "main": "index.js",
   "scripts": {
     "test": "eslint ."

--- a/react.js
+++ b/react.js
@@ -6,7 +6,7 @@ module.exports = {
 
   rules: {
     // Prevent missing displayName in a React component definition
-    'react/display-name': 0,
+    'react/display-name': [1, { acceptTranspilerName: true }],
     // Forbid certain propTypes
     'react/forbid-prop-types': 1,
     // Enforce boolean attributes notation in JSX
@@ -22,7 +22,7 @@ module.exports = {
     // Validate JSX indentation
     'react/jsx-indent': [1, 2],
     // Validate JSX has key prop when in array or iterator
-    'react/jsx-key': 0,
+    'react/jsx-key': 1,
     // Limit maximum of props on a single line in JSX
     'react/jsx-max-props-per-line': 0,
     // Prevent usage of .bind() and arrow functions in JSX props

--- a/react.js
+++ b/react.js
@@ -2,6 +2,84 @@ module.exports = {
   ecmaFeatures: {
     jsx: true
   },
+  plugins: ['react'],
 
-  rules: {}
+  rules: {
+    // Prevent missing displayName in a React component definition
+    'react/display-name': 0,
+    // Forbid certain propTypes
+    'react/forbid-prop-types': 1,
+    // Enforce boolean attributes notation in JSX
+    'react/jsx-boolean-value': 1,
+    // Validate closing bracket location in JSX
+    'react/jsx-closing-bracket-location': [1, "after-props"],
+    // Enforce or disallow spaces inside of curly braces in JSX attributes
+    'react/jsx-curly-spacing': 1,
+    // Enforce event handler naming conventions in JSX
+    'react/jsx-handler-names': 1,
+    // Validate props indentation in JSX
+    'react/jsx-indent-props': [1, 4],
+    // Validate JSX indentation
+    'react/jsx-indent': [1, 2],
+    // Validate JSX has key prop when in array or iterator
+    'react/jsx-key': 0,
+    // Limit maximum of props on a single line in JSX
+    'react/jsx-max-props-per-line': 0,
+    // Prevent usage of .bind() and arrow functions in JSX props
+    'react/jsx-no-bind': 0,
+    // Prevent duplicate props in JSX
+    'react/jsx-no-duplicate-props': 1,
+    // Prevent usage of unwrapped JSX strings
+    'react/jsx-no-literals': 0,
+    // Disallow undeclared variables in JSX
+    'react/jsx-no-undef': 1,
+    // Enforce PascalCase for user-defined JSX components
+    'react/jsx-pascal-case': 1,
+    // Enforce propTypes declarations alphabetical sorting
+    'react/jsx-sort-prop-types': [1, {
+      callbacksLast: true,
+      ignoreCase: true,
+      requiredFirst: true
+    }],
+    // Enforce props alphabetical sorting
+    'react/jsx-sort-props': 0,
+    // Prevent React to be incorrectly marked as unused
+    'react/jsx-uses-react': 1,
+    // Prevent variables used in JSX to be incorrectly marked as unused
+    'react/jsx-uses-vars': 1,
+    // Prevent usage of dangerous JSX properties
+    'react/no-danger': 1,
+    // Prevent usage of deprecated methods
+    'react/no-deprecated': 1,
+    // Prevent usage of setState in componentDidMount
+    'react/no-did-mount-set-state': 1,
+    // Prevent usage of setState in componentDidUpdate
+    'react/no-did-update-set-state': 1,
+    // Prevent direct mutation of this.state
+    'react/no-direct-mutation-state': 1,
+    // Prevent usage of isMounted
+    'react/no-is-mounted': 1,
+    // Prevent multiple component definition per file
+    'react/no-multi-comp': [1, { ignoreStateless: true }],
+    // Prevent usage of setState
+    'react/no-set-state': 1,
+    // Prevent using string references in ref attribute
+    'react/no-string-refs': 1,
+    // Prevent usage of unknown DOM property
+    'react/no-unknown-property': 1,
+    // Enforce ES5 or ES6 class for React Components
+    'react/prefer-es6-class': 1,
+    // Prevent missing props validation in a React component definition
+    'react/prop-types': 1,
+    // Prevent missing React when using JSX
+    'react/react-in-jsx-scope': 1,
+    // Restrict file extensions that may be required
+    'react/require-extension': 1,
+    // Prevent extra closing tags for components without children
+    'react/self-closing-comp': 1,
+    // Enforce component methods order
+    'react/sort-comp': 1,
+    // Prevent missing parentheses around multilines JSX
+    'react/wrap-multilines': 1
+  }
 };

--- a/react.js
+++ b/react.js
@@ -12,7 +12,7 @@ module.exports = {
     // Enforce boolean attributes notation in JSX
     'react/jsx-boolean-value': 1,
     // Validate closing bracket location in JSX
-    'react/jsx-closing-bracket-location': [1, "after-props"],
+    'react/jsx-closing-bracket-location': [1, 'after-props'],
     // Enforce or disallow spaces inside of curly braces in JSX attributes
     'react/jsx-curly-spacing': 1,
     // Enforce event handler naming conventions in JSX

--- a/react.js
+++ b/react.js
@@ -82,4 +82,4 @@ module.exports = {
     // Prevent missing parentheses around multilines JSX
     'react/wrap-multilines': 1
   }
-};
+}


### PR DESCRIPTION
Add lint rules representing Zeal’s preferred coding style for JavaScript projects, including Mocha and Chai-specific overrides, and additional rules for React projects.
