### PR TITLE
Use peerDependencies instead of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Zeal's JavaScript coding style is still evolving as we do more projects, but thi
 
 ## Install
 
-To make use of this configuration, install this package as a development dependency of your project:
+To make use of this configuration, install eslint, babel-eslint, and this package as development dependencies of your project:
 
 ```
-npm install eslint-config-zeal --save-dev
+npm install eslint babel-eslint eslint-config-zeal --save-dev
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
     "style checker",
     "style linter"
   ],
-  "dependencies": {
+  "devDependencies": {
+    "babel-eslint": "^4.1.6",
+    "eslint": "^1.10.3"
+  },
+  "peerDependencies": {
     "babel-eslint": "^4.1.6",
     "eslint": "^1.10.3"
   }


### PR DESCRIPTION
Using this package on other projects can cause dependency resolution
errors.  Change `dependencies` into `peerDependencies` and
`devDependencies` instead.

According to https://nodejs.org/en/blog/npm/peer-dependencies/,
`peerDependencies` are the right solution when defining a package that
acts as a plugin to another package as is the case here.
