### PR TITLE
react/jsx-space-before-closing rule too new

### DIFF
--- a/react.js
+++ b/react.js
@@ -47,8 +47,6 @@ module.exports = {
     }],
     // Enforce props alphabetical sorting
     'react/jsx-sort-props': 0,
-    // Validate spacing before closing bracket in JSX
-    'react/jsx-space-before-closing': 1,
     // Prevent React to be incorrectly marked as unused
     'react/jsx-uses-react': 1,
     // Prevent variables used in JSX to be incorrectly marked as unused


### PR DESCRIPTION
The `react/jsx-space-before-closing` rule is listed in the README of
eslint-plugin-react, but the version containing that rule hasn’t been
released yet, which gives us an error about an unknown rule definition.

We can add this rule back when we upgrade eslint-plugin-react again.

Fixes #5.
