### PR TITLE
Use eslint-plugin-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Zeal's JavaScript coding style is still evolving as we do more projects, but thi
 
 **NOTE:** The current version of this package is designed to work with ESLint 2.0 and greater.  If you are still using ESLint 1.x, use version 0.2.0 of this package instead.
 
-To make use of this configuration, install eslint, babel-eslint, and this package as development dependencies of your project:
+To make use of this configuration, install eslint, babel-eslint, eslint-plugin-import, and this package as development dependencies of your project:
 
 ```
-npm install eslint babel-eslint eslint-config-zeal --save-dev
+npm install eslint babel-eslint eslint-plugin-import eslint-config-zeal --save-dev
 ```
 
 These packages are marked as peer dependencies, so you will get a warning if they're not installed.
@@ -50,12 +50,55 @@ You can extend multiple configurations using an array:
 
 See the [ESLint configuration documentation](http://eslint.org/docs/user-guide/configuring) for more information on configuring ESLint.
 
+## Usage With React
+
+If you're using this package in a React project, make sure you have [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) installed as well:
+
+```
+npm install eslint-plugin-react --save-dev
+```
+
+Then, in your `.eslintrc` file, extend both the `zeal` and `zeal/react` configurations:
+
+```
+{
+  "extends": ["zeal", "zeal/react"]
+}
+```
+
+## Usage With Webpack
+
+This configuration uses [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import).  If your project uses Webpack, you'll need to add [eslint-import-resolver-webpack]():
+
+```
+npm install eslint-import-resolver-webpack
+```
+
+You'll also need to add the following to your `.eslintrc`:
+
+```
+"settings": {
+  "import/resolver": "webpack"
+}
+```
+
+or, if your webpack config file is not in the default location:
+
+```
+"settings": {
+  "import/resolver": {
+    "webpack": { "config": "path/to/webpack.config.js" }
+  }
+}
+```
+
 ## Supported Versions
 
 This plugin contains all of the rules available in:
 
 * [ESLint](http://eslint.org/): 2.0.0
 * [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 3.16.1
+* [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 1.0.0-beta.0
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,13 @@ module.exports = {
     ecmaVersion: 6,
     sourceType: 'module'
   },
+  plugins: ['import'],
+  settings: {
+    'import/ignore': [
+      'node_modules',
+      '.(scss|sass|less|css)$'
+    ]
+  },
   rules: {
     //
     // Possible Errors
@@ -457,6 +464,31 @@ module.exports = {
     // disallow generator functions that do not have yield
     'require-yield': 1,
     // enforce spacing around the * in yield* expressions
-    'yield-star-spacing': 1
+    'yield-star-spacing': 1,
+
+    //
+    // Import Plugin
+    //
+    // Ensure imports point to a file/module that can be resolved
+    'import/no-unresolved': [1, { commonjs: true }],
+    // Ensure named imports correspond to a named export in the remote file
+    'import/named': 1,
+    // Ensure a default export is present, given a default import
+    'import/default': 1,
+    // Ensure imported namespaces contain dereferenced properties as they are
+    // dereferenced
+    'import/namespace': 1,
+    // Report any invalid exports, i.e. re-export of the same name
+    'import/export': 1,
+    // Report use of exported name as identifier of default export
+    'import/no-named-as-default': 1,
+    // Report CommonJS require calls and module.exports or exports.*
+    'import/no-commonjs': 0,
+    // Report AMD require and define calls
+    'import/no-amd': 1,
+    // Ensure all imports appear before other statements
+    'import/imports-first': 1,
+    // Report repeated import of the same module in multiple places
+    'import/no-duplicates': 1
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,10 +34,12 @@
   ],
   "devDependencies": {
     "babel-eslint": "^4.1.7",
-    "eslint": "^2.0.0"
+    "eslint": "^2.0.0",
+    "eslint-plugin-import": "^1.0.0-beta.0"
   },
   "peerDependencies": {
     "babel-eslint": "^4.1.7",
-    "eslint": "^2.0.0"
+    "eslint": "^2.0.0",
+    "eslint-plugin-import": "^1.0.0-beta.0"
   }
 }


### PR DESCRIPTION
[eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) provides additional lint rules for checking ES6 import statements,
including ensuring that any imports match corresponding exports.

I ran a spike against our
[react-boilerplate](https://github.com/CodingZeal/react-boilerplate)
project, and these rules catch a few issues there, so they do seem to
have some effect.
