### PR TITLE
Disable newline-per-chained-call rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -330,7 +330,7 @@ module.exports = {
     // require or disallow an empty newline after variable declarations
     'newline-after-var': 1,
     //  enforce newline after each call when chaining the calls
-    'newline-per-chained-call': 1,
+    'newline-per-chained-call': 0,
     // disallow use of the Array constructor
     'no-array-constructor': 1,
     // disallow use of bitwise operators


### PR DESCRIPTION
This rule seemed useful, but in practice it just gets in the way,
especially when using chai expectations, but also calls like
`module.hot.accept(…)`.

We can just allow our taste and 80-character line-length limit address
the intent of this rule.
