### PR TITLE
Update configuration of react/display-name rule

### DIFF
--- a/react.js
+++ b/react.js
@@ -8,7 +8,7 @@ module.exports = {
 
   rules: {
     // Prevent missing displayName in a React component definition
-    'react/display-name': [1, { acceptTranspilerName: true }],
+    'react/display-name': 1,
     // Forbid certain propTypes
     'react/forbid-prop-types': 1,
     // Enforce boolean attributes notation in JSX


### PR DESCRIPTION
The configuration options for react/display-name changed in
eslint-plugin-react 4.x, so we need to update our configuration file.
