### PR TITLE
Upgrade to ESLint 2.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.  This proje
 
 ## [Unreleased](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.5.1...HEAD)
 
+### Added
+
+* Add support for new `template-curly-spacing`, `newline-before-return`, `no-restricted-globals`, and `react/prefer-stateless-function` rules. ([#11](https://github.com/CodingZeal/eslint-config-zeal/pull/7))
+
+### Changed
+
+* Update to ESLint 2.4.0, eslint-plugin-import 1.1.0, and eslint-plugin-react 4.2.3. Requires babel-eslint 6.0.0-beta.6 or later. ([#11](https://github.com/CodingZeal/eslint-config-zeal/pull/7))
+
 ## [0.5.1](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.5.0...v0.5.1) - 2016-03-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ or, if your webpack config file is not in the default location:
 
 This plugin contains all of the rules available in:
 
-* [ESLint](http://eslint.org/): 2.0.0
-* [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 4.1.0
-* [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 1.0.0-beta.0
+* [ESLint](http://eslint.org/): 2.4.0
+* [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 4.2.3
+* [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 1.1.0
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -234,6 +234,8 @@ module.exports = {
     'no-delete-var': 1,
     // disallow labels that share a name with a variable
     'no-label-var': 1,
+    // restrict usage of specified global variables
+    'no-restricted-globals': 0,
     // disallow shadowing of names such as arguments
     'no-shadow-restricted-names': 1,
     // disallow declaration of variables already declared in the outer scope
@@ -336,6 +338,8 @@ module.exports = {
     'new-parens': 1,
     // require or disallow an empty newline after variable declarations
     'newline-after-var': 1,
+    // require newline before return statement
+    'newline-before-return': 0,
     //  enforce newline after each call when chaining the calls
     'newline-per-chained-call': 0,
     // disallow use of the Array constructor

--- a/index.js
+++ b/index.js
@@ -463,6 +463,8 @@ module.exports = {
     'prefer-template': 1,
     // disallow generator functions that do not have yield
     'require-yield': 1,
+    // enforce spacing around embedded expressions of template strings
+    'template-curly-spacing': 1,
     // enforce spacing around the * in yield* expressions
     'yield-star-spacing': 1,
 

--- a/package.json
+++ b/package.json
@@ -34,14 +34,14 @@
     "style linter"
   ],
   "devDependencies": {
-    "babel-eslint": "^4.1.7",
-    "eslint": "^2.0.0",
+    "babel-eslint": "^6.0.0-beta.6",
+    "eslint": "^2.4.0",
     "eslint-find-new-rules": "^1.0.3",
-    "eslint-plugin-import": "^1.0.0-beta.0"
+    "eslint-plugin-import": "^1.1.0"
   },
   "peerDependencies": {
-    "babel-eslint": "^4.1.7",
-    "eslint": "^2.0.0",
-    "eslint-plugin-import": "^1.0.0-beta.0"
+    "babel-eslint": "^6.0.0-beta.6",
+    "eslint": "^2.4.0",
+    "eslint-plugin-import": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.5.1",
   "main": "index.js",
   "scripts": {
+    "find-new-rules": "eslint-find-new-rules",
     "test": "eslint ."
   },
   "repository": {
@@ -35,6 +36,7 @@
   "devDependencies": {
     "babel-eslint": "^4.1.7",
     "eslint": "^2.0.0",
+    "eslint-find-new-rules": "^1.0.3",
     "eslint-plugin-import": "^1.0.0-beta.0"
   },
   "peerDependencies": {

--- a/react.js
+++ b/react.js
@@ -69,6 +69,8 @@ module.exports = {
     'react/no-unknown-property': 1,
     // Enforce ES5 or ES6 class for React Components
     'react/prefer-es6-class': 1,
+    // Enforce stateless React Components to be written as a pure function
+    'react/prefer-stateless-function': 1,
     // Prevent missing props validation in a React component definition
     'react/prop-types': 1,
     // Prevent missing React when using JSX


### PR DESCRIPTION
Update to the latest version of ESLint and its plugins.

I found a handy new tool, eslint-find-new-rules, which will help us ensure that we catch all rules added by new versions of eslint.  You can run it via `npm run find-new-rules`.

It already caught one miss, `template-curly-spacing`, so I added it (enabled as a warning).

Add support for new rules:
- `newline-before-return`: disabled; not sure we want to enforce this
- `no-restricted-globals`: disabled; nothing we want to restrict, 
- `react/prefer-stateless-function`: enabled as a warning
