### PR TITLE
Disable max-statements in Mocha tests

### DIFF
--- a/mocha.js
+++ b/mocha.js
@@ -5,6 +5,8 @@ module.exports = {
 
   rules: {
     // specify the maximum depth callbacks can be nested
-    'max-nested-callbacks': 0
+    'max-nested-callbacks': 0,
+    // specify the maximum number of statement allowed in a function
+    'max-statements': 0
   }
 }


### PR DESCRIPTION
Often, Mocha specs will require more statements than allowed by the
`max-statements` rule. Sometimes it is possible to get around the issue
by adding nested describes and contexts, but if you define a number of
consts and helper functions, you can quickly run into the limit.

Fixes #13
