### PR TITLE
Disable react/prop-types rule

### DIFF
--- a/react.js
+++ b/react.js
@@ -72,7 +72,7 @@ module.exports = {
     // Enforce stateless React Components to be written as a pure function
     'react/prefer-stateless-function': 1,
     // Prevent missing props validation in a React component definition
-    'react/prop-types': 1,
+    'react/prop-types': 0,
     // Prevent missing React when using JSX
     'react/react-in-jsx-scope': 1,
     // Restrict file extensions that may be required


### PR DESCRIPTION
While propTypes are useful for documentation, we have decided that they are more painful to maintain than they are helpful, so we disable the
rule by default.
