### PR TITLE
Upgrade ESLint and friends to latest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can override settings from the configuration(s) by adding them directly to y
 
 We have added some additional optional configurations that you can add on top of the base `zeal` config:
 
-* `zeal/react`: Adds rules for [React](https://github.com/reactjs) development.  You'll need to install [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) `^4.0.0` to use this configuration.
+* `zeal/react`: Adds rules for [React](https://github.com/reactjs) development.  You'll need to install [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) `^5.1.1` to use this configuration.
 * `zeal/mocha`: Overrides rules for use with [Mocha](https://mochajs.org/).  We recommend creating a separate `.eslintrc` file in the directory containing your tests and `extend`ing this config there.
 * `zeal/chai`: Overrides rules for use with [Chai](http://chaijs.com/).  We recommend creating a separate `.eslintrc` file in the directory containing your tests and `extend`ing this config there.
 
@@ -68,7 +68,7 @@ Then, in your `.eslintrc` file, extend both the `zeal` and `zeal/react` configur
 
 ## Usage With Webpack
 
-This configuration uses [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import).  If your project uses Webpack, you'll need to add [eslint-import-resolver-webpack]():
+This configuration uses [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import).  If your project uses Webpack, you'll need to add [eslint-import-resolver-webpack](https://www.npmjs.com/package/eslint-import-resolver-webpack):
 
 ```
 npm install eslint-import-resolver-webpack
@@ -96,9 +96,9 @@ or, if your webpack config file is not in the default location:
 
 This plugin contains all of the rules available in:
 
-* [ESLint](http://eslint.org/): 2.4.0
-* [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 4.2.3
-* [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 1.1.0
+* [ESLint](http://eslint.org/): 2.10.2
+* [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 5.1.1
+* [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 1.8.0
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -73,6 +73,8 @@ module.exports = {
     // disallow unreachable statements after a return, throw, continue, or
     // break statement
     'no-unreachable': 1,
+    // disallow control flow statements in finally blocks
+    'no-unsafe-finally': 1,
     // disallow comparisons with the value NaN
     'use-isnan': 1,
     // Ensure JSDoc comments are valid
@@ -200,6 +202,8 @@ module.exports = {
     'no-useless-call': 1,
     // disallow unnecessary concatenation of literals or template literals
     'no-useless-concat': 1,
+    // disallow unnecessary escape characters
+    'no-useless-escape': 1,
     // disallow use of the void operator
     'no-void': 1,
     // disallow usage of configurable warning terms in comments - e.g. TODO
@@ -331,6 +335,8 @@ module.exports = {
     'max-params': [1, 3],
     // specify the maximum number of statement allowed in a function
     'max-statements': 1,
+    // enforce a maximum number of statements allowed per line
+    'max-statements-per-line': 0,
     // require a capital letter for constructors
     'new-cap': 1,
     // disallow the omission of parentheses when invoking a constructor with no
@@ -380,6 +386,8 @@ module.exports = {
     'no-unneeded-ternary': 1,
     // require or disallow padding inside curly braces
     'object-curly-spacing': [1, 'always'],
+    // enforce placing object properties on separate lines
+    'object-property-newline': 0,
     // require or disallow one variable declaration per function
     'one-var': [1, 'never'],
     // require or disallow an newline around variable declarations
@@ -442,10 +450,14 @@ module.exports = {
     'no-const-assign': 1,
     // disallow duplicate name in class members
     'no-dupe-class-members': 1,
+    // disallow duplicate module imports
+    'no-duplicate-imports': 1,
     // disallow use of the new operator with the Symbol object
     'no-new-symbol': 1,
     // disallow use of this/super before calling super() in constructors.
     'no-this-before-super': 1,
+    // disallow unnecessary computed property keys in object literals
+    'no-useless-computed-key': 1,
     // disallow unnecessary constructor
     'no-useless-constructor': 1,
     // require let or const instead of var
@@ -475,6 +487,8 @@ module.exports = {
     //
     // Import Plugin
     //
+    // Import: Static Analysis
+    //
     // Ensure imports point to a file/module that can be resolved
     'import/no-unresolved': [1, { commonjs: true }],
     // Ensure named imports correspond to a named export in the remote file
@@ -484,17 +498,48 @@ module.exports = {
     // Ensure imported namespaces contain dereferenced properties as they are
     // dereferenced
     'import/namespace': 1,
+
+    //
+    // Import: Helpful Warnings
+    //
     // Report any invalid exports, i.e. re-export of the same name
     'import/export': 1,
     // Report use of exported name as identifier of default export
     'import/no-named-as-default': 1,
+    // Report use of exported name as property of default export
+    'import/no-named-as-default-member': 1,
+    // Report imported names marked with @deprecated documentation tag
+    'import/no-deprecated': 1,
+    // Forbid the use of extraneous packages
+    'import/no-extraneous-dependencies': 1,
+    // Forbid the use of mutable exports with var or let.
+    'import/no-mutable-exports': 1,
+
+    //
+    // Import: Module Systems
     // Report CommonJS require calls and module.exports or exports.*
     'import/no-commonjs': 0,
     // Report AMD require and define calls
     'import/no-amd': 1,
+    // No Node.js builtin modules.
+    'import/no-nodejs-modules': 0,
+
+    //
+    // Import: Style guide
+    //
     // Ensure all imports appear before other statements
     'import/imports-first': 1,
     // Report repeated import of the same module in multiple places
-    'import/no-duplicates': 1
+    'import/no-duplicates': 1,
+    // Report namespace imports
+    'import/no-namespace': 0,
+    // Ensure consistent use of file extension within the import path
+    'import/extensions': 1,
+    // Enforce a convention in module import order
+    'import/order': 0,
+    // Enforce a newline after import statements
+    'import/newline-after-import': 1,
+    // Prefer a default export if module exports a single name
+    'import/prefer-default-export': 1
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.6.2",
   "main": "index.js",
   "scripts": {
-    "find-new-rules": "eslint-find-new-rules",
+    "find-new-rules": "eslint-find-rules --unused; eslint-find-rules --unused react.js | grep react",
     "test": "eslint ."
   },
   "repository": {
@@ -34,14 +34,15 @@
     "style linter"
   ],
   "devDependencies": {
-    "babel-eslint": "^6.0.0-beta.6",
-    "eslint": "^2.4.0",
-    "eslint-find-new-rules": "^1.0.3",
-    "eslint-plugin-import": "^1.1.0"
+    "babel-eslint": "^6.0.4",
+    "eslint": "^2.10.2",
+    "eslint-find-rules": "^1.9.2",
+    "eslint-plugin-import": "^1.8.0",
+    "eslint-plugin-react": "^5.1.1"
   },
   "peerDependencies": {
-    "babel-eslint": "^6.0.0-beta.6",
-    "eslint": "^2.4.0",
-    "eslint-plugin-import": "^1.1.0"
+    "babel-eslint": "^6.0.4",
+    "eslint": "^2.10.2",
+    "eslint-plugin-import": "^1.8.0"
   }
 }

--- a/react.js
+++ b/react.js
@@ -19,6 +19,8 @@ module.exports = {
     'react/jsx-curly-spacing': 1,
     // Enforce or disallow spaces around equal signs in JSX attributes
     'react/jsx-equals-spacing': 1,
+    // Enforce position of the first prop in JSX
+    'react/jsx-first-prop-new-line': [1, 'multiline'],
     // Enforce event handler naming conventions in JSX
     'react/jsx-handler-names': 1,
     // Validate props indentation in JSX
@@ -35,6 +37,8 @@ module.exports = {
     'react/jsx-no-duplicate-props': 1,
     // Prevent usage of unwrapped JSX strings
     'react/jsx-no-literals': 0,
+    // Prevent usage of unsafe target='_blank'
+    'react/jsx-no-target-blank': 1,
     // Disallow undeclared variables in JSX
     'react/jsx-no-undef': 1,
     // Enforce PascalCase for user-defined JSX components
@@ -77,6 +81,8 @@ module.exports = {
     'react/react-in-jsx-scope': 1,
     // Restrict file extensions that may be required
     'react/require-extension': 1,
+    // Enforce ES5 or ES6 class for returning value in render function
+    'react/require-render-return': 1,
     // Prevent extra closing tags for components without children
     'react/self-closing-comp': 1,
     // Enforce component methods order


### PR DESCRIPTION
- Upgrade dependency versions
- Add configuration for new rules
- Convert to eslint-find-rules from deprecated eslint-find-new-rules
- Add eslint-plugin-react to devDependencies to allow use of
  eslint-find-rules on react configuration

Fixes #14 
