### PR TITLE
Allow mixed arithmetic operators

### DIFF
--- a/index.js
+++ b/index.js
@@ -363,7 +363,16 @@ module.exports = {
     // disallow if as the only statement in an else block
     'no-lonely-if': 1,
     // disallow mixes of different operators
-    'no-mixed-operators': 1,
+    'no-mixed-operators': [1,
+      {
+        groups: [
+          ['&', '|', '^', '~', '<<', '>>', '>>>'],
+          ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
+          ['&&', '||'],
+          ['in', 'instanceof']
+        ]
+      }
+    ],
     // disallow mixed spaces and tabs for indentation
     'no-mixed-spaces-and-tabs': 1,
     // disallow multiple empty lines


### PR DESCRIPTION
The `no-mixed-operators` rule warns when mixing different operators in the same expression without explicitly using parentheses.

While this is generally a good warning, it’s annoying with arithmetic operations, because people generally understand the precedence of these operators (`*` and `/` before `+` and `-`).  So, this PR updates the `no-mixed-operators` rule to allow mixed arithmetic operators.  It still warns about bit-wise, comparison, and logical operators.
