### PR TITLE
Mark expect as a global when using Chai

### DIFF
--- a/chai.js
+++ b/chai.js
@@ -1,4 +1,7 @@
 module.exports = {
+  globals: {
+    expect: true
+  },
   rules: {
     // disallow usage of expressions in statement position
     'no-unused-expressions': 0


### PR DESCRIPTION
In some test running configurations (such as when using Karma), `expect` is treated as a global symbol and does not need to be imported.

This PR updates `chai.js` to mark `expect` as a global so ESLint doesn’t report it as an undefined value.
