### PR TITLE
Upgrade dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.8.1",
   "main": "index.js",
   "scripts": {
-    "find-new-rules": "eslint-find-rules --unused; eslint-find-rules --unused react.js | grep react",
+    "missing-rules": "eslint-find-rules --unused && eslint-find-rules --no-core --unused react.js",
     "test": "eslint ."
   },
   "repository": {
@@ -34,14 +34,14 @@
     "style linter"
   ],
   "devDependencies": {
-    "babel-eslint": "^6.0.4",
+    "babel-eslint": "^6.1.0",
     "eslint": "^2.13.1",
-    "eslint-find-rules": "^1.10.0",
+    "eslint-find-rules": "^1.13.0",
     "eslint-plugin-import": "^1.8.0",
     "eslint-plugin-react": "^5.2.2"
   },
   "peerDependencies": {
-    "babel-eslint": "^6.0.4",
+    "babel-eslint": "^6.1.0",
     "eslint": "^2.13.1",
     "eslint-plugin-import": "^1.8.0"
   }


### PR DESCRIPTION
- Rename `find-new-rules` script to `missing-rules` - simpler, and clearer about its purpose.
- Use latest babel-eslint
- Use latest eslint-find-rules
- Latest eslint-find-rules adds a new `—no-core` option which simplifies our `missing-rules` script.
