### PR TITLE
Update eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ or, if your webpack config file is not in the default location:
 This plugin contains all of the rules available in:
 
 * [ESLint](http://eslint.org/): 2.13.1
-* [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 5.2.2
+* [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 6.1.1
 * [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 1.13.0
 
 ## License

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ or, if your webpack config file is not in the default location:
 
 This plugin contains all of the rules available in:
 
-* [ESLint](http://eslint.org/): 2.13.1
+* [ESLint](http://eslint.org/): 3.3.1
 * [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 6.1.1
 * [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 1.13.0
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This plugin contains all of the rules available in:
 
 * [ESLint](http://eslint.org/): 2.13.1
 * [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 5.2.2
-* [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 1.8.0
+* [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 1.13.0
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -62,8 +62,6 @@ module.exports = {
     'no-invalid-regexp': 1,
     // disallow irregular whitespace outside of strings and comments
     'no-irregular-whitespace': 1,
-    // disallow negation of the left operand of an in expression
-    'no-negated-in-lhs': 1,
     // disallow the use of object properties of the global object (Math and
     // JSON) as functions
     'no-obj-calls': 1,
@@ -73,6 +71,8 @@ module.exports = {
     'no-regex-spaces': 1,
     // disallow sparse arrays
     'no-sparse-arrays': 1,
+    // Disallow template literal placeholder syntax in regular strings
+    'no-template-curly-in-string': 1,
     // Avoid code that looks like two expressions but is actually one
     'no-unexpected-multiline': 1,
     // disallow unreachable statements after a return, throw, continue, or
@@ -80,6 +80,8 @@ module.exports = {
     'no-unreachable': 1,
     // disallow control flow statements in finally blocks
     'no-unsafe-finally': 1,
+    // disallow negating the left operand of relational operators
+    'no-unsafe-negation': 1,
     // disallow comparisons with the value NaN
     'use-isnan': 1,
     // Ensure JSDoc comments are valid
@@ -141,6 +143,8 @@ module.exports = {
     // disallow the use of leading or trailing decimal points in numeric
     // literals
     'no-floating-decimal': 1,
+    // disallow assignments to native objects or read-only global variables
+    'no-global-assign': 1,
     // disallow the type conversions with shorter notations
     'no-implicit-coercion': 1,
     // disallow var and named functions in global scope
@@ -163,8 +167,6 @@ module.exports = {
     'no-multi-spaces': 1,
     // disallow use of multiline strings
     'no-multi-str': 1,
-    // disallow reassignments of native objects
-    'no-native-reassign': 1,
     // disallow use of new operator for Function object
     'no-new-func': 1,
     // disallows creating new instances of String,Number, and Boolean
@@ -306,6 +308,9 @@ module.exports = {
     'consistent-this': [1, 'self'],
     // enforce newline at the end of file, with no multiple empty lines
     'eol-last': 1,
+    // require or disallow spacing between function identifiers and their
+    // invocations
+    'func-call-spacing': 1,
     // require function expressions to have a name
     'func-names': 1,
     // enforce use of function declarations or expressions
@@ -344,6 +349,8 @@ module.exports = {
     'max-statements': 1,
     // enforce a maximum number of statements allowed per line
     'max-statements-per-line': 0,
+    // enforce newlines between operands of ternary expressions
+    'multiline-ternary': 0,
     // require a capital letter for constructors
     'new-cap': 1,
     // disallow the omission of parentheses when invoking a constructor with no
@@ -392,8 +399,8 @@ module.exports = {
     'no-restricted-syntax': 0,
     // disallow whitespace before properties
     'no-whitespace-before-property': 1,
-    // disallow space between function identifier and application
-    'no-spaced-func': 1,
+    // Disallow tabs in file
+    'no-tabs': 1,
     // disallow the use of ternary operators
     'no-ternary': 0,
     // disallow trailing whitespace at the end of lines
@@ -429,6 +436,8 @@ module.exports = {
     'semi-spacing': 1,
     // require or disallow use of semicolons instead of ASI
     semi: [1, 'never'],
+    // requires object keys to be sorted
+    'sort-keys': 0,
     // sort import declarations within module
     'sort-imports': 0,
     // sort variables within the same declaration block

--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ module.exports = {
   },
   globals: {},
   parserOptions: {
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true
+    },
     ecmaVersion: 6,
     sourceType: 'module'
   },

--- a/index.js
+++ b/index.js
@@ -522,6 +522,8 @@ module.exports = {
     // Ensure imported namespaces contain dereferenced properties as they are
     // dereferenced
     'import/namespace': 1,
+    // Restrict which files can be imported in a given folder
+    'import/no-restricted-paths': 0,
 
     //
     // Import: Helpful Warnings

--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
   ],
   "devDependencies": {
     "babel-eslint": "^6.1.0",
-    "eslint": "^2.13.1",
+    "eslint": "^3.3.1",
     "eslint-find-rules": "^1.13.0",
     "eslint-plugin-import": "^1.13.0",
     "eslint-plugin-react": "^6.1.1"
   },
   "peerDependencies": {
     "babel-eslint": "^6.1.0",
-    "eslint": "^2.13.1",
+    "eslint": "^3.3.1",
     "eslint-plugin-import": "^1.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "babel-eslint": "^6.1.0",
     "eslint": "^2.13.1",
     "eslint-find-rules": "^1.13.0",
-    "eslint-plugin-import": "^1.8.0",
+    "eslint-plugin-import": "^1.13.0",
     "eslint-plugin-react": "^5.2.2"
   },
   "peerDependencies": {
     "babel-eslint": "^6.1.0",
     "eslint": "^2.13.1",
-    "eslint-plugin-import": "^1.8.0"
+    "eslint-plugin-import": "^1.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.8.1",
   "main": "index.js",
   "scripts": {
-    "find-new-rules": "eslint-find-rules --unused; eslint-find-rules --unused react.js | grep react",
+    "missing-rules": "eslint-find-rules --unused && eslint-find-rules --no-core --unused react.js",
     "test": "eslint ."
   },
   "repository": {
@@ -34,14 +34,14 @@
     "style linter"
   ],
   "devDependencies": {
-    "babel-eslint": "^6.0.4",
+    "babel-eslint": "^6.1.0",
     "eslint": "^2.13.1",
-    "eslint-find-rules": "^1.10.0",
+    "eslint-find-rules": "^1.13.0",
     "eslint-plugin-import": "^1.8.0",
     "eslint-plugin-react": "^5.2.2"
   },
   "peerDependencies": {
-    "babel-eslint": "^6.0.4",
+    "babel-eslint": "^6.1.0",
     "eslint": "^2.13.1",
     "eslint-plugin-import": "^1.8.0"
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint": "^2.13.1",
     "eslint-find-rules": "^1.13.0",
     "eslint-plugin-import": "^1.13.0",
-    "eslint-plugin-react": "^5.2.2"
+    "eslint-plugin-react": "^6.1.1"
   },
   "peerDependencies": {
     "babel-eslint": "^6.1.0",

--- a/react.js
+++ b/react.js
@@ -62,7 +62,7 @@ module.exports = {
     // Prevent usage of dangerous JSX properties
     'react/no-danger': 1,
     // Prevent problem with children and props.dangerouslySetInnerHTML
-    'react/no-danger-with-children': 1,
+    'react/no-danger-with-children': 0,
     // Prevent usage of deprecated methods
     'react/no-deprecated': 1,
     // Prevent usage of setState in componentDidMount

--- a/react.js
+++ b/react.js
@@ -9,6 +9,8 @@ module.exports = {
   rules: {
     // Prevent missing displayName in a React component definition
     'react/display-name': 1,
+    // Forbid certain props on Components
+    'react/forbid-component-props': 0,
     // Forbid certain propTypes
     'react/forbid-prop-types': 1,
     // Enforce boolean attributes notation in JSX
@@ -35,6 +37,8 @@ module.exports = {
     'react/jsx-max-props-per-line': 0,
     // Prevent usage of .bind() and arrow functions in JSX props
     'react/jsx-no-bind': 0,
+    // Prevent comments from being inserted as text nodes
+    'react/jsx-no-comment-textnodes': 1,
     // Prevent duplicate props in JSX
     'react/jsx-no-duplicate-props': 1,
     // Prevent usage of unwrapped JSX strings
@@ -53,10 +57,12 @@ module.exports = {
     'react/jsx-uses-react': 1,
     // Prevent variables used in JSX to be incorrectly marked as unused
     'react/jsx-uses-vars': 1,
-    // Prevent comments from being inserted as text nodes
-    'react/no-comment-textnodes': 1,
+    // Prevent missing parentheses around multilines JSX
+    'react/jsx-wrap-multilines': 1,
     // Prevent usage of dangerous JSX properties
     'react/no-danger': 1,
+    // Prevent problem with children and props.dangerouslySetInnerHTML
+    'react/no-danger-with-children': 1,
     // Prevent usage of deprecated methods
     'react/no-deprecated': 1,
     // Prevent usage of setState in componentDidMount
@@ -65,6 +71,8 @@ module.exports = {
     'react/no-did-update-set-state': 1,
     // Prevent direct mutation of this.state
     'react/no-direct-mutation-state': 1,
+    // Prevent usage of findDOMNode
+    'react/no-find-dom-node': 1,
     // Prevent usage of isMounted
     'react/no-is-mounted': 1,
     // Prevent multiple component definition per file
@@ -85,8 +93,6 @@ module.exports = {
     'react/prop-types': 0,
     // Prevent missing React when using JSX
     'react/react-in-jsx-scope': 1,
-    // Restrict file extensions that may be required
-    'react/require-extension': 1,
     // Enforce React components to have a shouldComponentUpdate method
     'react/require-optimization': 0,
     // Enforce ES5 or ES6 class for returning value in render function
@@ -100,8 +106,6 @@ module.exports = {
       callbacksLast: true,
       ignoreCase: true,
       requiredFirst: true
-    }],
-    // Prevent missing parentheses around multilines JSX
-    'react/wrap-multilines': 1
+    }]
   }
 }


### PR DESCRIPTION
- Upgrade eslint-plugin-import to v1.13.0
  - Adds support for new rule `import/no-restricted-paths`, but leaves it disabled
- Upgrade eslint-plugin-react to v6.1.1
  - Add support for new rules: `react/forbid-component-props` (disabled by default), `react/no-danger-with-children`, and `react/no-find-dom-node`.
  - Rename `react/wrap-multilines` to `react/jsx-wrap-multilines`
  - Rename `react/no-comment-textnodes` to `react/jsx-no-comment-textnodes`
  - Remove deprecated `react/require-extension` rule.
- Upgrade eslint to v3.3.1
  - Add support for new rules: `no-template-curly-in-string`, `multiline-ternary` (disabled by default), `no-tabs`, `sort-keys` (disabled by default)
  - Replace deprecated rules with their replacements: `no-negated-in-lhs` -> `no-unsafe-negation`, `no-native-reassign` -> `no-global-assign`, `no-spaced-func` -> `func-call-spacing`
