### PR TITLE
Add react native support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ Then, in your `.eslintrc` file, extend both the `zeal` and `zeal/react` configur
 }
 ```
 
+## Usage with React Native
+
+If you're using this package in a React Native project, make sure you have both [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) and [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native) installed as well:
+
+```
+npm install eslint-plugin-react eslint-plugin-react-native --save-dev
+```
+
+Then, in your `.eslintrc` file, extend the `zeal`, `zeal/react`, and `zeal/react-native` configurations:
+
+```
+{
+  "extends": ["zeal", "zeal/react", "zeal/react-native"]
+}
+
 ## Usage With Webpack
 
 This configuration uses [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import).  If your project uses Webpack, you'll need to add [eslint-import-resolver-webpack](https://www.npmjs.com/package/eslint-import-resolver-webpack):

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ or, if your webpack config file is not in the default location:
 This plugin contains all of the rules available in:
 
 * [ESLint](http://eslint.org/): 2.13.1
-* [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 5.2.2
+* [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 6.1.1
 * [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 1.13.0
 
 ## License

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ or, if your webpack config file is not in the default location:
 
 This plugin contains all of the rules available in:
 
-* [ESLint](http://eslint.org/): 2.13.1
+* [ESLint](http://eslint.org/): 3.3.1
 * [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 6.1.1
 * [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 1.13.0
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This plugin contains all of the rules available in:
 
 * [ESLint](http://eslint.org/): 2.13.1
 * [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 5.2.2
-* [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 1.8.0
+* [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 1.13.0
 
 ## License
 

--- a/chai.js
+++ b/chai.js
@@ -4,6 +4,6 @@ module.exports = {
   },
   rules: {
     // disallow usage of expressions in statement position
-    'no-unused-expressions': 0
+    'no-unused-expressions': 'off'
   }
 }

--- a/index.js
+++ b/index.js
@@ -62,8 +62,6 @@ module.exports = {
     'no-invalid-regexp': 1,
     // disallow irregular whitespace outside of strings and comments
     'no-irregular-whitespace': 1,
-    // disallow negation of the left operand of an in expression
-    'no-negated-in-lhs': 1,
     // disallow the use of object properties of the global object (Math and
     // JSON) as functions
     'no-obj-calls': 1,
@@ -73,6 +71,8 @@ module.exports = {
     'no-regex-spaces': 1,
     // disallow sparse arrays
     'no-sparse-arrays': 1,
+    // Disallow template literal placeholder syntax in regular strings
+    'no-template-curly-in-string': 1,
     // Avoid code that looks like two expressions but is actually one
     'no-unexpected-multiline': 1,
     // disallow unreachable statements after a return, throw, continue, or
@@ -80,6 +80,8 @@ module.exports = {
     'no-unreachable': 1,
     // disallow control flow statements in finally blocks
     'no-unsafe-finally': 1,
+    // disallow negating the left operand of relational operators
+    'no-unsafe-negation': 1,
     // disallow comparisons with the value NaN
     'use-isnan': 1,
     // Ensure JSDoc comments are valid
@@ -141,6 +143,8 @@ module.exports = {
     // disallow the use of leading or trailing decimal points in numeric
     // literals
     'no-floating-decimal': 1,
+    // disallow assignments to native objects or read-only global variables
+    'no-global-assign': 1,
     // disallow the type conversions with shorter notations
     'no-implicit-coercion': 1,
     // disallow var and named functions in global scope
@@ -163,8 +167,6 @@ module.exports = {
     'no-multi-spaces': 1,
     // disallow use of multiline strings
     'no-multi-str': 1,
-    // disallow reassignments of native objects
-    'no-native-reassign': 1,
     // disallow use of new operator for Function object
     'no-new-func': 1,
     // disallows creating new instances of String,Number, and Boolean
@@ -306,6 +308,9 @@ module.exports = {
     'consistent-this': [1, 'self'],
     // enforce newline at the end of file, with no multiple empty lines
     'eol-last': 1,
+    // require or disallow spacing between function identifiers and their
+    // invocations
+    'func-call-spacing': 1,
     // require function expressions to have a name
     'func-names': 1,
     // enforce use of function declarations or expressions
@@ -344,6 +349,8 @@ module.exports = {
     'max-statements': 1,
     // enforce a maximum number of statements allowed per line
     'max-statements-per-line': 0,
+    // enforce newlines between operands of ternary expressions
+    'multiline-ternary': 0,
     // require a capital letter for constructors
     'new-cap': 1,
     // disallow the omission of parentheses when invoking a constructor with no
@@ -392,8 +399,8 @@ module.exports = {
     'no-restricted-syntax': 0,
     // disallow whitespace before properties
     'no-whitespace-before-property': 1,
-    // disallow space between function identifier and application
-    'no-spaced-func': 1,
+    // Disallow tabs in file
+    'no-tabs': 1,
     // disallow the use of ternary operators
     'no-ternary': 0,
     // disallow trailing whitespace at the end of lines
@@ -429,6 +436,8 @@ module.exports = {
     'semi-spacing': 1,
     // require or disallow use of semicolons instead of ASI
     semi: [1, 'never'],
+    // requires object keys to be sorted
+    'sort-keys': 0,
     // sort import declarations within module
     'sort-imports': 0,
     // sort variables within the same declaration block

--- a/index.js
+++ b/index.js
@@ -25,355 +25,355 @@ module.exports = {
     // Possible Errors
     //
     // disallow or enforce trailing commas
-    'comma-dangle': 1,
+    'comma-dangle': 'warn',
     // disallow assignment in conditional expressions
-    'no-cond-assign': 1,
+    'no-cond-assign': 'warn',
     // disallow use of console in the node environment
-    'no-console': 1,
+    'no-console': 'warn',
     // disallow use of constant expressions in conditions
-    'no-constant-condition': 1,
+    'no-constant-condition': 'warn',
     // disallow control characters in regular expressions
-    'no-control-regex': 1,
+    'no-control-regex': 'warn',
     // disallow use of debugger
-    'no-debugger': 1,
+    'no-debugger': 'warn',
     // disallow duplicate arguments in functions
-    'no-dupe-args': 1,
+    'no-dupe-args': 'warn',
     // disallow duplicate keys when creating object literals
-    'no-dupe-keys': 1,
+    'no-dupe-keys': 'warn',
     // disallow a duplicate case label.
-    'no-duplicate-case': 1,
+    'no-duplicate-case': 'warn',
     // disallow the use of empty character classes in regular expressions
-    'no-empty-character-class': 1,
+    'no-empty-character-class': 'warn',
     // disallow empty statements
-    'no-empty': 1,
+    'no-empty': 'warn',
     // disallow assigning to the exception in a catch block
-    'no-ex-assign': 1,
+    'no-ex-assign': 'warn',
     // disallow double-negation boolean casts in a boolean context
-    'no-extra-boolean-cast': 1,
+    'no-extra-boolean-cast': 'warn',
     // disallow unnecessary parentheses
-    'no-extra-parens': [1, 'functions'],
+    'no-extra-parens': ['warn', 'functions'],
     // disallow unnecessary semicolons
-    'no-extra-semi': 1,
+    'no-extra-semi': 'warn',
     // disallow overwriting functions written as function declarations
-    'no-func-assign': 1,
+    'no-func-assign': 'warn',
     // disallow function or variable declarations in nested blocks
-    'no-inner-declarations': [1, 'both'],
+    'no-inner-declarations': ['warn', 'both'],
     // disallow invalid regular expression strings in the RegExp constructor
-    'no-invalid-regexp': 1,
+    'no-invalid-regexp': 'warn',
     // disallow irregular whitespace outside of strings and comments
-    'no-irregular-whitespace': 1,
+    'no-irregular-whitespace': 'warn',
     // disallow the use of object properties of the global object (Math and
     // JSON) as functions
-    'no-obj-calls': 1,
+    'no-obj-calls': 'warn',
     // Disallow use of Object.prototypes builtins directly
-    'no-prototype-builtins': 1,
+    'no-prototype-builtins': 'warn',
     // disallow multiple spaces in a regular expression literal
-    'no-regex-spaces': 1,
+    'no-regex-spaces': 'warn',
     // disallow sparse arrays
-    'no-sparse-arrays': 1,
+    'no-sparse-arrays': 'warn',
     // Disallow template literal placeholder syntax in regular strings
-    'no-template-curly-in-string': 1,
+    'no-template-curly-in-string': 'warn',
     // Avoid code that looks like two expressions but is actually one
-    'no-unexpected-multiline': 1,
+    'no-unexpected-multiline': 'warn',
     // disallow unreachable statements after a return, throw, continue, or
     // break statement
-    'no-unreachable': 1,
+    'no-unreachable': 'warn',
     // disallow control flow statements in finally blocks
-    'no-unsafe-finally': 1,
+    'no-unsafe-finally': 'warn',
     // disallow negating the left operand of relational operators
-    'no-unsafe-negation': 1,
+    'no-unsafe-negation': 'warn',
     // disallow comparisons with the value NaN
-    'use-isnan': 1,
+    'use-isnan': 'warn',
     // Ensure JSDoc comments are valid
-    'valid-jsdoc': 1,
+    'valid-jsdoc': 'warn',
     // Ensure that the results of typeof are compared against a valid string
-    'valid-typeof': 1,
+    'valid-typeof': 'warn',
 
     //
     // Best Practices
     //
     // Enforces getter/setter pairs in objects
-    'accessor-pairs': 1,
+    'accessor-pairs': 'warn',
     // Enforces return statements in callbacks of array's methods
-    'array-callback-return': 1,
+    'array-callback-return': 'warn',
     // treat var statements as if they were block scoped
-    'block-scoped-var': 1,
+    'block-scoped-var': 'warn',
     // specify the maximum cyclomatic complexity allowed in a program
-    complexity: [1, 2],
+    complexity: ['warn', 2],
     // require return statements to either always or never specify values
-    'consistent-return': 1,
+    'consistent-return': 'warn',
     // specify curly brace conventions for all control statements
-    curly: [1, 'multi-line'],
+    curly: ['warn', 'multi-line'],
     // require default case in switch statements
-    'default-case': 1,
+    'default-case': 'warn',
     // enforces consistent newlines before or after dots
-    'dot-location': [1, 'property'],
+    'dot-location': ['warn', 'property'],
     // encourages use of dot notation whenever possible
-    'dot-notation': 1,
+    'dot-notation': 'warn',
     // require the use of === and !==
-    eqeqeq: 1,
+    eqeqeq: 'warn',
     // make sure for-in loops have an if statement
-    'guard-for-in': 1,
+    'guard-for-in': 'warn',
     // disallow the use of alert, confirm, and prompt
-    'no-alert': 1,
+    'no-alert': 'warn',
     // disallow use of arguments.caller or arguments.callee
-    'no-caller': 1,
+    'no-caller': 'warn',
     // disallow lexical declarations in case clauses
-    'no-case-declarations': 1,
+    'no-case-declarations': 'warn',
     // disallow division operators explicitly at beginning of regular expression
-    'no-div-regex': 1,
+    'no-div-regex': 'warn',
     // disallow else after a return in an if
-    'no-else-return': 1,
+    'no-else-return': 'warn',
     // disallow use of empty functions
-    'no-empty-function': 1,
+    'no-empty-function': 'warn',
     // disallow use of empty destructuring patterns
-    'no-empty-pattern': 1,
+    'no-empty-pattern': 'warn',
     // disallow comparisons to null without a type-checking operator
-    'no-eq-null': 1,
+    'no-eq-null': 'warn',
     // disallow use of eval()
-    'no-eval': 1,
+    'no-eval': 'warn',
     // disallow adding to native types
-    'no-extend-native': 1,
+    'no-extend-native': 'warn',
     // disallow unnecessary function binding
-    'no-extra-bind': 1,
+    'no-extra-bind': 'warn',
     // disallow unnecessary labels
-    'no-extra-label': 1,
+    'no-extra-label': 'warn',
     // disallow fallthrough of case statements
-    'no-fallthrough': 1,
+    'no-fallthrough': 'warn',
     // disallow the use of leading or trailing decimal points in numeric
     // literals
-    'no-floating-decimal': 1,
+    'no-floating-decimal': 'warn',
     // disallow assignments to native objects or read-only global variables
-    'no-global-assign': 1,
+    'no-global-assign': 'warn',
     // disallow the type conversions with shorter notations
-    'no-implicit-coercion': 1,
+    'no-implicit-coercion': 'warn',
     // disallow var and named functions in global scope
-    'no-implicit-globals': 1,
+    'no-implicit-globals': 'warn',
     // disallow use of eval()-like methods
-    'no-implied-eval': 1,
+    'no-implied-eval': 'warn',
     // disallow this keywords outside of classes or class-like objects
-    'no-invalid-this': 1,
+    'no-invalid-this': 'warn',
     // disallow usage of __iterator__ property
-    'no-iterator': 1,
+    'no-iterator': 'warn',
     // disallow use of labeled statements
-    'no-labels': 1,
+    'no-labels': 'warn',
     // disallow unnecessary nested blocks
-    'no-lone-blocks': 1,
+    'no-lone-blocks': 'warn',
     // disallow creation of functions within loops
-    'no-loop-func': 1,
+    'no-loop-func': 'warn',
     // disallow the use of magic numbers
-    'no-magic-numbers': 0,
+    'no-magic-numbers': 'off',
     // disallow use of multiple spaces
-    'no-multi-spaces': 1,
+    'no-multi-spaces': 'warn',
     // disallow use of multiline strings
-    'no-multi-str': 1,
+    'no-multi-str': 'warn',
     // disallow use of new operator for Function object
-    'no-new-func': 1,
+    'no-new-func': 'warn',
     // disallows creating new instances of String,Number, and Boolean
-    'no-new-wrappers': 1,
+    'no-new-wrappers': 'warn',
     // disallow use of the new operator when not part of an assignment or
     // comparison
-    'no-new': 1,
+    'no-new': 'warn',
     // disallow use of octal escape sequences in string literals, such as var
     // foo = "Copyright \251";
-    'no-octal-escape': 1,
+    'no-octal-escape': 'warn',
     // disallow use of octal literals
-    'no-octal': 1,
+    'no-octal': 'warn',
     // disallow reassignment of function parameters
-    'no-param-reassign': 1,
+    'no-param-reassign': 'warn',
     // disallow use of process.env
-    'no-process-env': 1,
+    'no-process-env': 'warn',
     // disallow usage of __proto__ property
-    'no-proto': 1,
+    'no-proto': 'warn',
     // disallow declaring the same variable more than once
-    'no-redeclare': 1,
+    'no-redeclare': 'warn',
     // disallow use of assignment in return statement
-    'no-return-assign': 1,
+    'no-return-assign': 'warn',
     // disallow use of javascript: urls.
-    'no-script-url': 1,
+    'no-script-url': 'warn',
     // disallow assignments where both sides are exactly the same
-    'no-self-assign': 1,
+    'no-self-assign': 'warn',
     // disallow comparisons where both sides are exactly the same
-    'no-self-compare': 1,
+    'no-self-compare': 'warn',
     // disallow use of the comma operator
-    'no-sequences': 1,
+    'no-sequences': 'warn',
     // restrict what can be thrown as an exception
-    'no-throw-literal': 1,
+    'no-throw-literal': 'warn',
     // disallow unmodified conditions of loops
-    'no-unmodified-loop-condition': 1,
+    'no-unmodified-loop-condition': 'warn',
     // disallow usage of expressions in statement position
-    'no-unused-expressions': 1,
+    'no-unused-expressions': 'warn',
     // disallow unused labels
-    'no-unused-labels': 1,
+    'no-unused-labels': 'warn',
     // disallow unnecessary .call() and .apply()
-    'no-useless-call': 1,
+    'no-useless-call': 'warn',
     // disallow unnecessary concatenation of literals or template literals
-    'no-useless-concat': 1,
+    'no-useless-concat': 'warn',
     // disallow unnecessary escape characters
-    'no-useless-escape': 1,
+    'no-useless-escape': 'warn',
     // disallow use of the void operator
-    'no-void': 1,
+    'no-void': 'warn',
     // disallow usage of configurable warning terms in comments - e.g. TODO
     // or FIXME
-    'no-warning-comments': 1,
+    'no-warning-comments': 'warn',
     // disallow use of the with statement
-    'no-with': 1,
+    'no-with': 'warn',
     // require use of the second argument for parseInt()
-    radix: 1,
+    radix: 'warn',
     // require declaration of all vars at the top of their containing scope
-    'vars-on-top': 1,
+    'vars-on-top': 'warn',
     // require immediate function invocation to be wrapped in parentheses
-    'wrap-iife': 1,
+    'wrap-iife': 'warn',
     // require or disallow Yoda conditions
-    yoda: 1,
+    yoda: 'warn',
 
     //
     // Strict Mode
     //
     // controls location of Use Strict Directives
-    strict: [1, 'never'],
+    strict: ['warn', 'never'],
 
     //
     // Variables
     //
     // enforce or disallow variable initializations at definition
-    'init-declarations': 1,
+    'init-declarations': 'warn',
     // disallow the catch clause parameter name being the same as a variable in
     // the outer scope
-    'no-catch-shadow': 1,
+    'no-catch-shadow': 'warn',
     // disallow deletion of variables
-    'no-delete-var': 1,
+    'no-delete-var': 'warn',
     // disallow labels that share a name with a variable
-    'no-label-var': 1,
+    'no-label-var': 'warn',
     // restrict usage of specified global variables
-    'no-restricted-globals': 0,
+    'no-restricted-globals': 'off',
     // disallow shadowing of names such as arguments
-    'no-shadow-restricted-names': 1,
+    'no-shadow-restricted-names': 'warn',
     // disallow declaration of variables already declared in the outer scope
-    'no-shadow': 1,
+    'no-shadow': 'warn',
     // disallow use of undefined when initializing variables
-    'no-undef-init': 1,
+    'no-undef-init': 'warn',
     // disallow use of undeclared variables unless mentioned in a /*global */
     // block
-    'no-undef': 1,
+    'no-undef': 'warn',
     // disallow use of undefined variable
-    'no-undefined': 0,
+    'no-undefined': 'off',
     // disallow declaration of variables that are not used in the code
-    'no-unused-vars': 1,
+    'no-unused-vars': 'warn',
     // disallow use of variables before they are defined
-    'no-use-before-define': [1, 'nofunc'],
+    'no-use-before-define': ['warn', 'nofunc'],
 
     //
     // Node.js and CommonJS
     //
     // enforce return after a callback
-    'callback-return': 1,
+    'callback-return': 'warn',
     // enforce require() on top-level module scope
-    'global-require': 1,
+    'global-require': 'warn',
     // enforce error handling in callbacks
-    'handle-callback-err': 1,
+    'handle-callback-err': 'warn',
     // disallow mixing regular variable and require declarations
-    'no-mixed-requires': 1,
+    'no-mixed-requires': 'warn',
     // disallow use of new operator with the require function
-    'no-new-require': 1,
+    'no-new-require': 'warn',
     // disallow string concatenation with __dirname and __filename
-    'no-path-concat': 1,
+    'no-path-concat': 'warn',
     // disallow process.exit()
-    'no-process-exit': 1,
+    'no-process-exit': 'warn',
     // restrict usage of specified node imports
-    'no-restricted-imports': 0,
+    'no-restricted-imports': 'off',
     // restrict usage of specified node modules
-    'no-restricted-modules': 0,
+    'no-restricted-modules': 'off',
     // disallow use of synchronous methods
-    'no-sync': 1,
+    'no-sync': 'warn',
 
     //
     // Stylistic Issues
     //
     // enforce spacing inside array brackets
-    'array-bracket-spacing': 1,
+    'array-bracket-spacing': 'warn',
     // disallow or enforce spaces inside of single line blocks
-    'block-spacing': 1,
+    'block-spacing': 'warn',
     // enforce one true brace style
-    'brace-style': 1,
+    'brace-style': 'warn',
     // require camel case names
-    camelcase: 1,
+    camelcase: 'warn',
     // enforce spacing before and after comma
-    'comma-spacing': 1,
+    'comma-spacing': 'warn',
     // enforce one true comma style
-    'comma-style': 1,
+    'comma-style': 'warn',
     // require or disallow padding inside computed properties
-    'computed-property-spacing': 1,
+    'computed-property-spacing': 'warn',
     // enforce consistent naming when capturing the current execution context
-    'consistent-this': [1, 'self'],
+    'consistent-this': ['warn', 'self'],
     // enforce newline at the end of file, with no multiple empty lines
-    'eol-last': 1,
+    'eol-last': 'warn',
     // require or disallow spacing between function identifiers and their
     // invocations
-    'func-call-spacing': 1,
+    'func-call-spacing': 'warn',
     // require function expressions to have a name
-    'func-names': 1,
+    'func-names': 'warn',
     // enforce use of function declarations or expressions
-    'func-style': [1, 'declaration', { allowArrowFunctions: true }],
+    'func-style': ['warn', 'declaration', { allowArrowFunctions: true }],
     // blacklist certain identifiers to prevent them being used
-    'id-blacklist': 0,
+    'id-blacklist': 'off',
     // this option enforces minimum and maximum identifier lengths (variable
     // names, property names etc.)
-    'id-length': 0,
+    'id-length': 'off',
     // require identifiers to match the provided regular expression
-    'id-match': 0,
+    'id-match': 'off',
     // specify tab or space width for your code
-    indent: [1, 2, { SwitchCase: 1 }],
+    indent: ['warn', 2, { SwitchCase: 1 }],
     // specify whether double or single quotes should be used in JSX attributes
-    'jsx-quotes': [1, 'prefer-single'],
+    'jsx-quotes': ['warn', 'prefer-single'],
     // enforce spacing between keys and values in object literal properties
-    'key-spacing': 1,
+    'key-spacing': 'warn',
     // enforce spacing before and after keywords
-    'keyword-spacing': 1,
+    'keyword-spacing': 'warn',
     // disallow mixed 'LF' and 'CRLF' as linebreaks
-    'linebreak-style': 1,
+    'linebreak-style': 'warn',
     // enforce empty lines around comments
-    'lines-around-comment': 1,
+    'lines-around-comment': 'warn',
     // specify the maximum depth that blocks can be nested
-    'max-depth': 1,
+    'max-depth': 'warn',
     // specify the maximum length of a line in your program
-    'max-len': [1, 80, 2],
+    'max-len': ['warn', 80, 2],
     // enforce a maximum file length
-    'max-lines': 0,
+    'max-lines': 'off',
     // specify the maximum depth callbacks can be nested
-    'max-nested-callbacks': [1, 3],
+    'max-nested-callbacks': ['warn', 3],
     // limits the number of parameters that can be used in the function
     // declaration.
-    'max-params': [1, 3],
+    'max-params': ['warn', 3],
     // specify the maximum number of statement allowed in a function
-    'max-statements': 1,
+    'max-statements': 'warn',
     // enforce a maximum number of statements allowed per line
-    'max-statements-per-line': 0,
+    'max-statements-per-line': 'off',
     // enforce newlines between operands of ternary expressions
-    'multiline-ternary': 0,
+    'multiline-ternary': 'off',
     // require a capital letter for constructors
-    'new-cap': 1,
+    'new-cap': 'warn',
     // disallow the omission of parentheses when invoking a constructor with no
     // arguments
-    'new-parens': 1,
+    'new-parens': 'warn',
     // require or disallow an empty newline after variable declarations
-    'newline-after-var': 1,
+    'newline-after-var': 'warn',
     // require newline before return statement
-    'newline-before-return': 0,
+    'newline-before-return': 'off',
     //  enforce newline after each call when chaining the calls
-    'newline-per-chained-call': 0,
+    'newline-per-chained-call': 'off',
     // disallow use of the Array constructor
-    'no-array-constructor': 1,
+    'no-array-constructor': 'warn',
     // disallow use of bitwise operators
-    'no-bitwise': 1,
+    'no-bitwise': 'warn',
     // disallow use of the continue statement
-    'no-continue': 1,
+    'no-continue': 'warn',
     // disallow comments inline after code
-    'no-inline-comments': 0,
+    'no-inline-comments': 'off',
     // disallow if as the only statement in an else block
-    'no-lonely-if': 1,
+    'no-lonely-if': 'warn',
     // disallow mixes of different operators
-    'no-mixed-operators': [1,
+    'no-mixed-operators': ['warn',
       {
         groups: [
           ['&', '|', '^', '~', '<<', '>>', '>>>'],
@@ -384,141 +384,141 @@ module.exports = {
       }
     ],
     // disallow mixed spaces and tabs for indentation
-    'no-mixed-spaces-and-tabs': 1,
+    'no-mixed-spaces-and-tabs': 'warn',
     // disallow multiple empty lines
-    'no-multiple-empty-lines': [1, { max: 1 }],
+    'no-multiple-empty-lines': ['warn', { max: 1 }],
     // disallow negated conditions
-    'no-negated-condition': 1,
+    'no-negated-condition': 'warn',
     // disallow nested ternary expressions
-    'no-nested-ternary': 1,
+    'no-nested-ternary': 'warn',
     // disallow the use of the Object constructor
-    'no-new-object': 1,
+    'no-new-object': 'warn',
     // disallow use of unary operators, ++ and --
-    'no-plusplus': 1,
+    'no-plusplus': 'warn',
     // disallow use of certain syntax in code
-    'no-restricted-syntax': 0,
+    'no-restricted-syntax': 'off',
     // disallow whitespace before properties
-    'no-whitespace-before-property': 1,
+    'no-whitespace-before-property': 'warn',
     // Disallow tabs in file
-    'no-tabs': 1,
+    'no-tabs': 'warn',
     // disallow the use of ternary operators
-    'no-ternary': 0,
+    'no-ternary': 'off',
     // disallow trailing whitespace at the end of lines
-    'no-trailing-spaces': 1,
+    'no-trailing-spaces': 'warn',
     // disallow dangling underscores in identifiers
-    'no-underscore-dangle': 1,
+    'no-underscore-dangle': 'warn',
     // disallow the use of ternary operators when a simpler alternative exists
-    'no-unneeded-ternary': 1,
+    'no-unneeded-ternary': 'warn',
     // enforce consistent line breaks inside braces
-    'object-curly-newline': 0,
+    'object-curly-newline': 'off',
     // require or disallow padding inside curly braces
-    'object-curly-spacing': [1, 'always'],
+    'object-curly-spacing': ['warn', 'always'],
     // enforce placing object properties on separate lines
-    'object-property-newline': 0,
+    'object-property-newline': 'off',
     // require or disallow one variable declaration per function
-    'one-var': [1, 'never'],
+    'one-var': ['warn', 'never'],
     // require or disallow an newline around variable declarations
-    'one-var-declaration-per-line': 1,
+    'one-var-declaration-per-line': 'warn',
     // require assignment operator shorthand where possible or prohibit it
     // entirely
-    'operator-assignment': [1, 'always'],
+    'operator-assignment': ['warn', 'always'],
     // enforce operators to be placed before or after line breaks
-    'operator-linebreak': 1,
+    'operator-linebreak': 'warn',
     // enforce padding within blocks
-    'padded-blocks': [1, 'never'],
+    'padded-blocks': ['warn', 'never'],
     // require quotes around object literal property names
-    'quote-props': [1, 'as-needed'],
+    'quote-props': ['warn', 'as-needed'],
     // specify whether backticks, double or single quotes should be used
-    quotes: [1, 'single', 'avoid-escape'],
+    quotes: ['warn', 'single', 'avoid-escape'],
     // Require JSDoc comment
-    'require-jsdoc': 0,
+    'require-jsdoc': 'off',
     // enforce spacing before and after semicolons
-    'semi-spacing': 1,
+    'semi-spacing': 'warn',
     // require or disallow use of semicolons instead of ASI
-    semi: [1, 'never'],
+    semi: ['warn', 'never'],
     // requires object keys to be sorted
-    'sort-keys': 0,
+    'sort-keys': 'off',
     // sort import declarations within module
-    'sort-imports': 0,
+    'sort-imports': 'off',
     // sort variables within the same declaration block
-    'sort-vars': 0,
+    'sort-vars': 'off',
     // require or disallow a space before blocks
-    'space-before-blocks': 1,
+    'space-before-blocks': 'warn',
     // require or disallow a space before function opening parenthesis
-    'space-before-function-paren': [1, 'never'],
+    'space-before-function-paren': ['warn', 'never'],
     // require or disallow spaces inside parentheses
-    'space-in-parens': 1,
+    'space-in-parens': 'warn',
     // require spaces around operators
-    'space-infix-ops': 1,
+    'space-infix-ops': 'warn',
     // require or disallow spaces before/after unary operators
-    'space-unary-ops': 1,
+    'space-unary-ops': 'warn',
     // require or disallow a space immediately following the // or /* in a
     // comment
-    'spaced-comment': 1,
+    'spaced-comment': 'warn',
     // require or disallow the Unicode BOM
-    'unicode-bom': 1,
+    'unicode-bom': 'warn',
     // require regex literals to be wrapped in parentheses
-    'wrap-regex': 1,
+    'wrap-regex': 'warn',
 
     //
     // ECMAScript 6
     //
     // require braces in arrow function body
-    'arrow-body-style': 1,
+    'arrow-body-style': 'warn',
     // require parens in arrow function arguments
-    'arrow-parens': [1, 'as-needed'],
+    'arrow-parens': ['warn', 'as-needed'],
     // require space before/after arrow function's arrow
-    'arrow-spacing': 1,
+    'arrow-spacing': 'warn',
     // verify calls of super() in constructors
-    'constructor-super': 1,
+    'constructor-super': 'warn',
     // enforce spacing around the * in generator functions
-    'generator-star-spacing': [1, 'after'],
+    'generator-star-spacing': ['warn', 'after'],
     // disallow modifying variables of class declarations
-    'no-class-assign': 1,
+    'no-class-assign': 'warn',
     // disallow arrow functions where they could be confused with comparisons
-    'no-confusing-arrow': 0,
+    'no-confusing-arrow': 'off',
     // disallow modifying variables that are declared using const
-    'no-const-assign': 1,
+    'no-const-assign': 'warn',
     // disallow duplicate name in class members
-    'no-dupe-class-members': 1,
+    'no-dupe-class-members': 'warn',
     // disallow duplicate module imports
-    'no-duplicate-imports': 1,
+    'no-duplicate-imports': 'warn',
     // disallow use of the new operator with the Symbol object
-    'no-new-symbol': 1,
+    'no-new-symbol': 'warn',
     // disallow use of this/super before calling super() in constructors.
-    'no-this-before-super': 1,
+    'no-this-before-super': 'warn',
     // disallow unnecessary computed property keys in object literals
-    'no-useless-computed-key': 1,
+    'no-useless-computed-key': 'warn',
     // disallow unnecessary constructor
-    'no-useless-constructor': 1,
+    'no-useless-constructor': 'warn',
     // disallow renaming import, export, and destructured assignments to the
     // same name
-    'no-useless-rename': 1,
+    'no-useless-rename': 'warn',
     // require let or const instead of var
-    'no-var': 1,
+    'no-var': 'warn',
     // require method and property shorthand syntax for object literals
-    'object-shorthand': 1,
+    'object-shorthand': 'warn',
     // suggest using arrow functions as callbacks
-    'prefer-arrow-callback': 1,
+    'prefer-arrow-callback': 'warn',
     // suggest using const declaration for variables that are never modified
     // after declared
-    'prefer-const': 1,
+    'prefer-const': 'warn',
     // suggest using Reflect methods where applicable
-    'prefer-reflect': 0,
+    'prefer-reflect': 'off',
     // suggest using the rest parameters instead of arguments
-    'prefer-rest-params': 1,
+    'prefer-rest-params': 'warn',
     // suggest using the spread operator instead of .apply().
-    'prefer-spread': 1,
+    'prefer-spread': 'warn',
     // suggest using template literals instead of strings concatenation
-    'prefer-template': 1,
+    'prefer-template': 'warn',
     // disallow generator functions that do not have yield
-    'require-yield': 1,
+    'require-yield': 'warn',
     // enforce spacing between rest and spread operators and their expressions
-    'rest-spread-spacing': 1,
+    'rest-spread-spacing': 'warn',
     // enforce spacing around embedded expressions of template strings
-    'template-curly-spacing': 1,
+    'template-curly-spacing': 'warn',
     // enforce spacing around the * in yield* expressions
-    'yield-star-spacing': 1,
+    'yield-star-spacing': 'warn',
 
     //
     // Import Plugin
@@ -526,58 +526,58 @@ module.exports = {
     // Import: Static Analysis
     //
     // Ensure imports point to a file/module that can be resolved
-    'import/no-unresolved': [1, { commonjs: true }],
+    'import/no-unresolved': ['warn', { commonjs: true }],
     // Ensure named imports correspond to a named export in the remote file
-    'import/named': 1,
+    'import/named': 'warn',
     // Ensure a default export is present, given a default import
-    'import/default': 1,
+    'import/default': 'warn',
     // Ensure imported namespaces contain dereferenced properties as they are
     // dereferenced
-    'import/namespace': 1,
+    'import/namespace': 'warn',
     // Restrict which files can be imported in a given folder
-    'import/no-restricted-paths': 0,
+    'import/no-restricted-paths': 'off',
 
     //
     // Import: Helpful Warnings
     //
     // Report any invalid exports, i.e. re-export of the same name
-    'import/export': 1,
+    'import/export': 'warn',
     // Report use of exported name as identifier of default export
-    'import/no-named-as-default': 1,
+    'import/no-named-as-default': 'warn',
     // Report use of exported name as property of default export
-    'import/no-named-as-default-member': 1,
+    'import/no-named-as-default-member': 'warn',
     // Report imported names marked with @deprecated documentation tag
-    'import/no-deprecated': 1,
+    'import/no-deprecated': 'warn',
     // Forbid the use of extraneous packages
-    'import/no-extraneous-dependencies': 1,
+    'import/no-extraneous-dependencies': 'warn',
     // Forbid the use of mutable exports with var or let.
-    'import/no-mutable-exports': 1,
+    'import/no-mutable-exports': 'warn',
 
     //
     // Import: Module Systems
     // Report CommonJS require calls and module.exports or exports.*
-    'import/no-commonjs': 0,
+    'import/no-commonjs': 'off',
     // Report AMD require and define calls
-    'import/no-amd': 1,
+    'import/no-amd': 'warn',
     // No Node.js builtin modules.
-    'import/no-nodejs-modules': 0,
+    'import/no-nodejs-modules': 'off',
 
     //
     // Import: Style guide
     //
     // Ensure all imports appear before other statements
-    'import/imports-first': 1,
+    'import/imports-first': 'warn',
     // Report repeated import of the same module in multiple places
-    'import/no-duplicates': 1,
+    'import/no-duplicates': 'warn',
     // Report namespace imports
-    'import/no-namespace': 0,
+    'import/no-namespace': 'off',
     // Ensure consistent use of file extension within the import path
-    'import/extensions': 1,
+    'import/extensions': 'warn',
     // Enforce a convention in module import order
-    'import/order': 0,
+    'import/order': 'off',
     // Enforce a newline after import statements
-    'import/newline-after-import': 1,
+    'import/newline-after-import': 'warn',
     // Prefer a default export if module exports a single name
-    'import/prefer-default-export': 1
+    'import/prefer-default-export': 'warn'
   }
 }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ module.exports = {
   },
   globals: {},
   parserOptions: {
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true
+    },
     ecmaVersion: 6,
     sourceType: 'module'
   },

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 module.exports = {
-  parser: 'babel-eslint',
   env: {
     browser: true,
     node: true,
     es6: true
   },
   globals: {},
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaFeatures: {
       experimentalObjectRestSpread: true

--- a/index.js
+++ b/index.js
@@ -522,6 +522,8 @@ module.exports = {
     // Ensure imported namespaces contain dereferenced properties as they are
     // dereferenced
     'import/namespace': 1,
+    // Restrict which files can be imported in a given folder
+    'import/no-restricted-paths': 0,
 
     //
     // Import: Helpful Warnings

--- a/mocha.js
+++ b/mocha.js
@@ -5,8 +5,8 @@ module.exports = {
 
   rules: {
     // specify the maximum depth callbacks can be nested
-    'max-nested-callbacks': 0,
+    'max-nested-callbacks': 'off',
     // specify the maximum number of statement allowed in a function
-    'max-statements': 0
+    'max-statements': 'off'
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
   ],
   "devDependencies": {
     "babel-eslint": "^6.1.0",
-    "eslint": "^2.13.1",
+    "eslint": "^3.3.1",
     "eslint-find-rules": "^1.13.0",
     "eslint-plugin-import": "^1.13.0",
     "eslint-plugin-react": "^6.1.1"
   },
   "peerDependencies": {
     "babel-eslint": "^6.1.0",
-    "eslint": "^2.13.1",
+    "eslint": "^3.3.1",
     "eslint-plugin-import": "^1.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "babel-eslint": "^6.1.0",
     "eslint": "^2.13.1",
     "eslint-find-rules": "^1.13.0",
-    "eslint-plugin-import": "^1.8.0",
+    "eslint-plugin-import": "^1.13.0",
     "eslint-plugin-react": "^5.2.2"
   },
   "peerDependencies": {
     "babel-eslint": "^6.1.0",
     "eslint": "^2.13.1",
-    "eslint-plugin-import": "^1.8.0"
+    "eslint-plugin-import": "^1.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.8.1",
   "main": "index.js",
   "scripts": {
-    "find-new-rules": "eslint-find-rules --unused; eslint-find-rules --unused react.js | grep react",
+    "missing-rules": "eslint-find-rules --unused && eslint-find-rules --no-core --unused react.js",
     "test": "eslint ."
   },
   "repository": {
@@ -34,14 +34,14 @@
     "style linter"
   ],
   "devDependencies": {
-    "babel-eslint": "^6.0.4",
+    "babel-eslint": "^6.1.0",
     "eslint": "^2.13.1",
-    "eslint-find-rules": "^1.10.0",
+    "eslint-find-rules": "^1.13.0",
     "eslint-plugin-import": "^1.8.0",
     "eslint-plugin-react": "^5.2.2"
   },
   "peerDependencies": {
-    "babel-eslint": "^6.0.4",
+    "babel-eslint": "^6.1.0",
     "eslint": "^2.13.1",
     "eslint-plugin-import": "^1.8.0"
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint": "^2.13.1",
     "eslint-find-rules": "^1.13.0",
     "eslint-plugin-import": "^1.13.0",
-    "eslint-plugin-react": "^5.2.2"
+    "eslint-plugin-react": "^6.1.1"
   },
   "peerDependencies": {
     "babel-eslint": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "version": "0.8.1",
   "main": "index.js",
   "scripts": {
-    "missing-rules": "eslint-find-rules --unused && eslint-find-rules --no-core --unused react.js",
+    "missing-rules": "npm-run-all --parallel missing-rules:*",
+    "missing-rules:core": "eslint-find-rules --unused",
+    "missing-rules:react": "eslint-find-rules --no-core --unused react.js",
+    "missing-rules:react-native": "eslint-find-rules --no-core --unused react-native.js",
     "test": "eslint ."
   },
   "repository": {
@@ -38,7 +41,9 @@
     "eslint": "^3.3.1",
     "eslint-find-rules": "^1.13.0",
     "eslint-plugin-import": "^1.13.0",
-    "eslint-plugin-react": "^6.1.1"
+    "eslint-plugin-react": "^6.1.1",
+    "eslint-plugin-react-native": "^2.0.0",
+    "npm-run-all": "^2.2.2"
   },
   "peerDependencies": {
     "babel-eslint": "^6.1.0",

--- a/react-native.js
+++ b/react-native.js
@@ -1,0 +1,17 @@
+module.exports = {
+  extends: [
+    'plugin:import/react-native'
+  ],
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true
+    }
+  },
+  plugins: ['react-native'],
+  rules: {
+    'react-native/no-unused-styles': 'warn',
+    'react-native/split-platform-components': 'warn',
+    'react-native/no-inline-styles': 'warn',
+    'react-native/no-color-literals': 'warn'
+  }
+}

--- a/react.js
+++ b/react.js
@@ -62,7 +62,7 @@ module.exports = {
     // Prevent usage of dangerous JSX properties
     'react/no-danger': 1,
     // Prevent problem with children and props.dangerouslySetInnerHTML
-    'react/no-danger-with-children': 1,
+    'react/no-danger-with-children': 0,
     // Prevent usage of deprecated methods
     'react/no-deprecated': 1,
     // Prevent usage of setState in componentDidMount

--- a/react.js
+++ b/react.js
@@ -9,6 +9,8 @@ module.exports = {
   rules: {
     // Prevent missing displayName in a React component definition
     'react/display-name': 1,
+    // Forbid certain props on Components
+    'react/forbid-component-props': 0,
     // Forbid certain propTypes
     'react/forbid-prop-types': 1,
     // Enforce boolean attributes notation in JSX
@@ -35,6 +37,8 @@ module.exports = {
     'react/jsx-max-props-per-line': 0,
     // Prevent usage of .bind() and arrow functions in JSX props
     'react/jsx-no-bind': 0,
+    // Prevent comments from being inserted as text nodes
+    'react/jsx-no-comment-textnodes': 1,
     // Prevent duplicate props in JSX
     'react/jsx-no-duplicate-props': 1,
     // Prevent usage of unwrapped JSX strings
@@ -53,10 +57,12 @@ module.exports = {
     'react/jsx-uses-react': 1,
     // Prevent variables used in JSX to be incorrectly marked as unused
     'react/jsx-uses-vars': 1,
-    // Prevent comments from being inserted as text nodes
-    'react/no-comment-textnodes': 1,
+    // Prevent missing parentheses around multilines JSX
+    'react/jsx-wrap-multilines': 1,
     // Prevent usage of dangerous JSX properties
     'react/no-danger': 1,
+    // Prevent problem with children and props.dangerouslySetInnerHTML
+    'react/no-danger-with-children': 1,
     // Prevent usage of deprecated methods
     'react/no-deprecated': 1,
     // Prevent usage of setState in componentDidMount
@@ -65,6 +71,8 @@ module.exports = {
     'react/no-did-update-set-state': 1,
     // Prevent direct mutation of this.state
     'react/no-direct-mutation-state': 1,
+    // Prevent usage of findDOMNode
+    'react/no-find-dom-node': 1,
     // Prevent usage of isMounted
     'react/no-is-mounted': 1,
     // Prevent multiple component definition per file
@@ -85,8 +93,6 @@ module.exports = {
     'react/prop-types': 0,
     // Prevent missing React when using JSX
     'react/react-in-jsx-scope': 1,
-    // Restrict file extensions that may be required
-    'react/require-extension': 1,
     // Enforce React components to have a shouldComponentUpdate method
     'react/require-optimization': 0,
     // Enforce ES5 or ES6 class for returning value in render function
@@ -100,8 +106,6 @@ module.exports = {
       callbacksLast: true,
       ignoreCase: true,
       requiredFirst: true
-    }],
-    // Prevent missing parentheses around multilines JSX
-    'react/wrap-multilines': 1
+    }]
   }
 }

--- a/react.js
+++ b/react.js
@@ -8,101 +8,101 @@ module.exports = {
 
   rules: {
     // Prevent missing displayName in a React component definition
-    'react/display-name': 1,
+    'react/display-name': 'warn',
     // Forbid certain props on Components
-    'react/forbid-component-props': 0,
+    'react/forbid-component-props': 'off',
     // Forbid certain propTypes
-    'react/forbid-prop-types': 1,
+    'react/forbid-prop-types': 'warn',
     // Enforce boolean attributes notation in JSX
-    'react/jsx-boolean-value': 1,
+    'react/jsx-boolean-value': 'warn',
     // Validate closing bracket location in JSX
-    'react/jsx-closing-bracket-location': [1, 'after-props'],
+    'react/jsx-closing-bracket-location': ['warn', 'after-props'],
     // Enforce or disallow spaces inside of curly braces in JSX attributes
-    'react/jsx-curly-spacing': 1,
+    'react/jsx-curly-spacing': 'warn',
     // Enforce or disallow spaces around equal signs in JSX attributes
-    'react/jsx-equals-spacing': 1,
+    'react/jsx-equals-spacing': 'warn',
     // Restrict file extensions that may contain JSX
-    'react/jsx-filename-extension': 0,
+    'react/jsx-filename-extension': 'off',
     // Enforce position of the first prop in JSX
-    'react/jsx-first-prop-new-line': [1, 'multiline'],
+    'react/jsx-first-prop-new-line': ['warn', 'multiline'],
     // Enforce event handler naming conventions in JSX
-    'react/jsx-handler-names': 1,
+    'react/jsx-handler-names': 'warn',
     // Validate props indentation in JSX
-    'react/jsx-indent-props': [1, 4],
+    'react/jsx-indent-props': ['warn', 4],
     // Validate JSX indentation
-    'react/jsx-indent': [1, 2],
+    'react/jsx-indent': ['warn', 2],
     // Validate JSX has key prop when in array or iterator
-    'react/jsx-key': 1,
+    'react/jsx-key': 'warn',
     // Limit maximum of props on a single line in JSX
-    'react/jsx-max-props-per-line': 0,
+    'react/jsx-max-props-per-line': 'off',
     // Prevent usage of .bind() and arrow functions in JSX props
-    'react/jsx-no-bind': 0,
+    'react/jsx-no-bind': 'off',
     // Prevent comments from being inserted as text nodes
-    'react/jsx-no-comment-textnodes': 1,
+    'react/jsx-no-comment-textnodes': 'warn',
     // Prevent duplicate props in JSX
-    'react/jsx-no-duplicate-props': 1,
+    'react/jsx-no-duplicate-props': 'warn',
     // Prevent usage of unwrapped JSX strings
-    'react/jsx-no-literals': 0,
+    'react/jsx-no-literals': 'off',
     // Prevent usage of unsafe target='_blank'
-    'react/jsx-no-target-blank': 1,
+    'react/jsx-no-target-blank': 'warn',
     // Disallow undeclared variables in JSX
-    'react/jsx-no-undef': 1,
+    'react/jsx-no-undef': 'warn',
     // Enforce PascalCase for user-defined JSX components
-    'react/jsx-pascal-case': 1,
+    'react/jsx-pascal-case': 'warn',
     // Enforce props alphabetical sorting
-    'react/jsx-sort-props': 0,
+    'react/jsx-sort-props': 'off',
     // Validate spacing before closing bracket in JSX
-    'react/jsx-space-before-closing': 1,
+    'react/jsx-space-before-closing': 'warn',
     // Prevent React to be incorrectly marked as unused
-    'react/jsx-uses-react': 1,
+    'react/jsx-uses-react': 'warn',
     // Prevent variables used in JSX to be incorrectly marked as unused
-    'react/jsx-uses-vars': 1,
+    'react/jsx-uses-vars': 'warn',
     // Prevent missing parentheses around multilines JSX
-    'react/jsx-wrap-multilines': 1,
+    'react/jsx-wrap-multilines': 'warn',
     // Prevent usage of dangerous JSX properties
-    'react/no-danger': 1,
+    'react/no-danger': 'warn',
     // Prevent problem with children and props.dangerouslySetInnerHTML
-    'react/no-danger-with-children': 0,
+    'react/no-danger-with-children': 'off',
     // Prevent usage of deprecated methods
-    'react/no-deprecated': 1,
+    'react/no-deprecated': 'warn',
     // Prevent usage of setState in componentDidMount
-    'react/no-did-mount-set-state': 1,
+    'react/no-did-mount-set-state': 'warn',
     // Prevent usage of setState in componentDidUpdate
-    'react/no-did-update-set-state': 1,
+    'react/no-did-update-set-state': 'warn',
     // Prevent direct mutation of this.state
-    'react/no-direct-mutation-state': 1,
+    'react/no-direct-mutation-state': 'warn',
     // Prevent usage of findDOMNode
-    'react/no-find-dom-node': 1,
+    'react/no-find-dom-node': 'warn',
     // Prevent usage of isMounted
-    'react/no-is-mounted': 1,
+    'react/no-is-mounted': 'warn',
     // Prevent multiple component definition per file
-    'react/no-multi-comp': [1, { ignoreStateless: true }],
+    'react/no-multi-comp': ['warn', { ignoreStateless: true }],
     // Prevent usage of the return value of React.render
-    'react/no-render-return-value': 1,
+    'react/no-render-return-value': 'warn',
     // Prevent usage of setState
-    'react/no-set-state': 1,
+    'react/no-set-state': 'warn',
     // Prevent using string references in ref attribute
-    'react/no-string-refs': 1,
+    'react/no-string-refs': 'warn',
     // Prevent usage of unknown DOM property
-    'react/no-unknown-property': 1,
+    'react/no-unknown-property': 'warn',
     // Enforce ES5 or ES6 class for React Components
-    'react/prefer-es6-class': 1,
+    'react/prefer-es6-class': 'warn',
     // Enforce stateless React Components to be written as a pure function
-    'react/prefer-stateless-function': 1,
+    'react/prefer-stateless-function': 'warn',
     // Prevent missing props validation in a React component definition
-    'react/prop-types': 0,
+    'react/prop-types': 'off',
     // Prevent missing React when using JSX
-    'react/react-in-jsx-scope': 1,
+    'react/react-in-jsx-scope': 'warn',
     // Enforce React components to have a shouldComponentUpdate method
-    'react/require-optimization': 0,
+    'react/require-optimization': 'off',
     // Enforce ES5 or ES6 class for returning value in render function
-    'react/require-render-return': 1,
+    'react/require-render-return': 'warn',
     // Prevent extra closing tags for components without children
-    'react/self-closing-comp': 1,
+    'react/self-closing-comp': 'warn',
     // Enforce component methods order
-    'react/sort-comp': 1,
+    'react/sort-comp': 'warn',
     // Enforce propTypes declarations alphabetical sorting
-    'react/sort-prop-types': [1, {
+    'react/sort-prop-types': ['warn', {
       callbacksLast: true,
       ignoreCase: true,
       requiredFirst: true


### PR DESCRIPTION
Add a separate optional config for react-native.  Extend the `import/react-native` config in order properly recognize platform-specific imports when checking for unresolved imports.

As with Mocha/Chai, `zeal/react-native` is separate from `zeal/react` to allow more flexibility in client use at the cost of having to extend two separate configs in the client project.
