### PR TITLE
Update eslint-plugin-react to v6.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ or, if your webpack config file is not in the default location:
 This plugin contains all of the rules available in:
 
 * [ESLint](http://eslint.org/): 3.3.1
-* [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 6.1.1
+* [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 6.1.2
 * [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native): 2.0.0
 * [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 1.13.0
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint": "^3.3.1",
     "eslint-find-rules": "^1.13.0",
     "eslint-plugin-import": "^1.13.0",
-    "eslint-plugin-react": "^6.1.1",
+    "eslint-plugin-react": "^6.1.2",
     "eslint-plugin-react-native": "^2.0.0",
     "npm-run-all": "^2.2.2"
   },

--- a/react.js
+++ b/react.js
@@ -62,7 +62,7 @@ module.exports = {
     // Prevent usage of dangerous JSX properties
     'react/no-danger': 'warn',
     // Prevent problem with children and props.dangerouslySetInnerHTML
-    'react/no-danger-with-children': 'off',
+    'react/no-danger-with-children': 'warn',
     // Prevent usage of deprecated methods
     'react/no-deprecated': 'warn',
     // Prevent usage of setState in componentDidMount


### PR DESCRIPTION
This release fixes the `react/no-danger-with-children` issue, allowing us to re-enable that rule.

Fixes #26.
