### PR TITLE
Upgrade to latest eslint and friends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - '4.2'
+  - '4'
   - node

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - '4'
   - node

--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ or, if your webpack config file is not in the default location:
 
 This plugin contains all of the rules available in:
 
-* [ESLint](http://eslint.org/): 3.5.0
+* [ESLint](http://eslint.org/): 3.7.0
 * [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 6.3.0
 * [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native): 2.0.0
-* [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 1.15.0
+* [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 2.0.0
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -554,6 +554,8 @@ module.exports = {
     'import/no-dynamic-require': 'warn',
     // Prevent importing the submodules of other modules
     'import/no-internal-modules': 'off',
+    // Forbid Webpack loader syntax in imports
+    'import/no-webpack-loader-syntax': 'warn',
 
     //
     // Import: Helpful Warnings
@@ -573,6 +575,8 @@ module.exports = {
 
     //
     // Import: Module Systems
+    // Report potentially ambiguous parse goal (script vs. module)
+    'import/unambiguous': 'off',
     // Report CommonJS require calls and module.exports or exports.*
     'import/no-commonjs': 'off',
     // Report AMD require and define calls
@@ -584,7 +588,7 @@ module.exports = {
     // Import: Style guide
     //
     // Ensure all imports appear before other statements
-    'import/imports-first': 'warn',
+    'import/first': 'warn',
     // Report repeated import of the same module in multiple places
     'import/no-duplicates': 'warn',
     // Report namespace imports
@@ -598,6 +602,8 @@ module.exports = {
     // Prefer a default export if module exports a single name
     'import/prefer-default-export': 'warn',
     // Limit the maximum number of dependencies a module can have.
-    'import/max-dependencies': 'off'
+    'import/max-dependencies': 'off',
+    // Forbid unassigned imports.
+    'import/no-unassigned-import': 'off'
   }
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = {
     ecmaFeatures: {
       experimentalObjectRestSpread: true
     },
-    ecmaVersion: 6,
+    ecmaVersion: 2017,
     sourceType: 'module'
   },
   plugins: ['import'],

--- a/index.js
+++ b/index.js
@@ -550,6 +550,10 @@ module.exports = {
     'import/no-restricted-paths': 'off',
     // Forbid import of modules using absolute paths
     'import/no-absolute-path': 'warn',
+    // Forbid require() calls with expressions
+    'import/no-dynamic-require': 'warn',
+    // Prevent importing the submodules of other modules
+    'import/no-internal-modules': 'off',
 
     //
     // Import: Helpful Warnings

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-eslint": "^7.0.0",
     "eslint": "^3.7.0",
     "eslint-find-rules": "^1.14.0",
-    "eslint-plugin-import": "^1.16.0",
+    "eslint-plugin-import": "^2.0.0",
     "eslint-plugin-react": "^6.3.0",
     "eslint-plugin-react-native": "^2.0.0",
     "npm-run-all": "^3.1.0"
@@ -48,6 +48,6 @@
   "peerDependencies": {
     "babel-eslint": "^7.0.0",
     "eslint": "^3.7.0",
-    "eslint-plugin-import": "^1.16.0"
+    "eslint-plugin-import": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "devDependencies": {
     "babel-eslint": "^6.1.0",
-    "eslint": "^3.6.0",
+    "eslint": "^3.6.1",
     "eslint-find-rules": "^1.14.0",
     "eslint-plugin-import": "^1.15.0",
     "eslint-plugin-react": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "devDependencies": {
     "babel-eslint": "^6.1.0",
-    "eslint": "^3.6.1",
+    "eslint": "^3.7.0",
     "eslint-find-rules": "^1.14.0",
     "eslint-plugin-import": "^1.15.0",
     "eslint-plugin-react": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-eslint": "^7.0.0",
     "eslint": "^3.7.0",
     "eslint-find-rules": "^1.14.0",
-    "eslint-plugin-import": "^1.15.0",
+    "eslint-plugin-import": "^1.16.0",
     "eslint-plugin-react": "^6.3.0",
     "eslint-plugin-react-native": "^2.0.0",
     "npm-run-all": "^3.1.0"
@@ -48,6 +48,6 @@
   "peerDependencies": {
     "babel-eslint": "^7.0.0",
     "eslint": "^3.7.0",
-    "eslint-plugin-import": "^1.15.0"
+    "eslint-plugin-import": "^1.16.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "babel-eslint": "^6.1.0",
     "eslint": "^3.5.0",
-    "eslint-find-rules": "^1.13.2",
+    "eslint-find-rules": "^1.14.0",
     "eslint-plugin-import": "^1.15.0",
     "eslint-plugin-react": "^6.3.0",
     "eslint-plugin-react-native": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "style linter"
   ],
   "devDependencies": {
-    "babel-eslint": "^6.1.0",
+    "babel-eslint": "^7.0.0",
     "eslint": "^3.7.0",
     "eslint-find-rules": "^1.14.0",
     "eslint-plugin-import": "^1.15.0",
@@ -46,8 +46,8 @@
     "npm-run-all": "^3.1.0"
   },
   "peerDependencies": {
-    "babel-eslint": "^6.1.0",
-    "eslint": "^3.5.0",
+    "babel-eslint": "^7.0.0",
+    "eslint": "^3.7.0",
     "eslint-plugin-import": "^1.15.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "devDependencies": {
     "babel-eslint": "^6.1.0",
-    "eslint": "^3.5.0",
+    "eslint": "^3.6.0",
     "eslint-find-rules": "^1.14.0",
     "eslint-plugin-import": "^1.15.0",
     "eslint-plugin-react": "^6.3.0",


### PR DESCRIPTION
- ESLint 3.7.0
- babel-eslint 7.0.0
- eslint-plugin-import 2.0
- eslint-find-rules

The new rule, `import/no-internal-modules` seems like it could be useful, but we’d need to configure it with exceptions that are likely project- and environment specific, so I’ve left it turned off.  I recommend configuring it for your particular project.

Closes #32 
