### PR TITLE
Minimize size of npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "ESLint sharable configuration matching Zeal's style guide",
   "version": "0.15.0",
   "main": "index.js",
+  "files": ["*.js"],
   "scripts": {
     "missing-rules": "run-p missing-rules:*",
     "missing-rules:core": "eslint-find-rules --unused",


### PR DESCRIPTION
Specify `files` to only include the eslint configuration files.

npm will automatically include `package.json` and admin files like `README`, `CHANGELOG`, and `LICENSE`.