### PR TITLE
Switch from Travis to CircleCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - node

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # eslint-config-zeal
 
 [![npm version](https://badge.fury.io/js/eslint-config-zeal.svg)](https://www.npmjs.com/package/eslint-config-zeal)
-[![Build Status](https://travis-ci.org/CodingZeal/eslint-config-zeal.svg?branch=master)](https://travis-ci.org/CodingZeal/eslint-config-zeal)
+[![CircleCI](https://circleci.com/gh/CodingZeal/eslint-config-zeal.svg?style=svg)](https://circleci.com/gh/CodingZeal/eslint-config-zeal)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 A [shareable ESLint config](http://eslint.org/docs/developer-guide/shareable-configs) for Zeal's coding style.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # eslint-config-zeal
 
 [![npm version](https://badge.fury.io/js/eslint-config-zeal.svg)](https://www.npmjs.com/package/eslint-config-zeal)
-[![CircleCI](https://circleci.com/gh/CodingZeal/eslint-config-zeal.svg?style=svg)](https://circleci.com/gh/CodingZeal/eslint-config-zeal)
+[![CircleCI](https://circleci.com/gh/CodingZeal/eslint-config-zeal.svg?style=shield)](https://circleci.com/gh/CodingZeal/eslint-config-zeal)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 A [shareable ESLint config](http://eslint.org/docs/developer-guide/shareable-configs) for Zeal's coding style.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+machine:
+  environment:
+    PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+  node:
+    version:
+      6.9.4
+dependencies:
+  cache_directories:
+    - ~/.cache/yarn
+  override:
+    - yarn
+test:
+  override:
+    - yarn test


### PR DESCRIPTION
We build all of our other projects on Circle, so it doesn’t make sense to have this one oddball.

**TODO**:
- [x] Add Circle configuration
- [x] Enable project on Circle
- [x] Switch README badge from Travis to Circle
- [x] Disable project on Travis
- [x] Remove Travis configuration
