### PR TITLE
Update rule configuration to match our current practice

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ module.exports = {
     // enforce that class methods utilize this
     'class-methods-use-this': 'off',
     // specify the maximum cyclomatic complexity allowed in a program
-    complexity: ['warn', 2],
+    complexity: ['warn', 3],
     // require return statements to either always or never specify values
     'consistent-return': 'warn',
     // specify curly brace conventions for all control statements
@@ -156,7 +156,7 @@ module.exports = {
     // disallow use of eval()-like methods
     'no-implied-eval': 'warn',
     // disallow this keywords outside of classes or class-like objects
-    'no-invalid-this': 'warn',
+    'no-invalid-this': 'off',
     // disallow usage of __iterator__ property
     'no-iterator': 'warn',
     // disallow use of labeled statements
@@ -208,7 +208,10 @@ module.exports = {
     // disallow unmodified conditions of loops
     'no-unmodified-loop-condition': 'warn',
     // disallow usage of expressions in statement position
-    'no-unused-expressions': 'warn',
+    'no-unused-expressions': ['warn', {
+      allowShortCircuit: true,
+      allowTernary: true
+    }],
     // disallow unused labels
     'no-unused-labels': 'warn',
     // disallow unnecessary .call() and .apply()
@@ -269,7 +272,7 @@ module.exports = {
     // disallow use of undefined variable
     'no-undefined': 'off',
     // disallow declaration of variables that are not used in the code
-    'no-unused-vars': 'warn',
+    'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
     // disallow use of variables before they are defined
     'no-use-before-define': ['warn', 'nofunc'],
 
@@ -427,7 +430,7 @@ module.exports = {
     // disallow trailing whitespace at the end of lines
     'no-trailing-spaces': 'warn',
     // disallow dangling underscores in identifiers
-    'no-underscore-dangle': 'warn',
+    'no-underscore-dangle': 'off',
     // disallow the use of ternary operators when a simpler alternative exists
     'no-unneeded-ternary': 'warn',
     // enforce consistent line breaks inside braces
@@ -578,9 +581,9 @@ module.exports = {
     // Report any invalid exports, i.e. re-export of the same name
     'import/export': 'warn',
     // Report use of exported name as identifier of default export
-    'import/no-named-as-default': 'warn',
+    'import/no-named-as-default': 'off',
     // Report use of exported name as property of default export
-    'import/no-named-as-default-member': 'warn',
+    'import/no-named-as-default-member': 'off',
     // Report imported names marked with @deprecated documentation tag
     'import/no-deprecated': 'warn',
     // Forbid the use of extraneous packages
@@ -609,13 +612,13 @@ module.exports = {
     // Report namespace imports
     'import/no-namespace': 'off',
     // Ensure consistent use of file extension within the import path
-    'import/extensions': 'warn',
+    'import/extensions': ['warn', 'never', { scss: 'always' }],
     // Enforce a convention in module import order
     'import/order': 'off',
     // Enforce a newline after import statements
     'import/newline-after-import': 'warn',
     // Prefer a default export if module exports a single name
-    'import/prefer-default-export': 'warn',
+    'import/prefer-default-export': 'off',
     // Limit the maximum number of dependencies a module can have.
     'import/max-dependencies': 'off',
     // Forbid unassigned imports.

--- a/react.js
+++ b/react.js
@@ -86,7 +86,7 @@ module.exports = {
     // Prevent usage of the return value of React.render
     'react/no-render-return-value': 'warn',
     // Prevent usage of setState
-    'react/no-set-state': 'warn',
+    'react/no-set-state': 'off',
     // Prevent using string references in ref attribute
     'react/no-string-refs': 'warn',
     // Prevent invalid characters from appearing in markup


### PR DESCRIPTION
Update the configuration of several rules to match what we normally use on our projects.

Here’s the rationale for each of these changes:

- `complexity`: Change maximum allowed complexity from 2 to 3.  We knew 2 was probably too low when we started, but we didn’t know how big to make it.  After some experience, we now think 3 is pretty good for most of our projects.  We’ll use comments to bump the level up on a case-by-case basis where needed.  We rarely write code that needs more than 4.

- `no-invalid-this`: This rule doesn’t yet properly support class property syntax, so we disable it in almost all of our projects.

- `no-unused-expressions`: We often relax this rule to allow short-circuiting (`someCondition && someAction()`) or ternary expressions (`return someCondition ? someAction() : null`).

- `no-unused-vars`: Add an `argsIgnorePattern` to allow us to use `_unusedVar` when we want to explicitly name an unused function argument.  This is made possible by the change to `no-underscore-dangle`.

- `no-underscore-dangle`: There are cases, such as when working with third-party software, that underscores are required, so we now disable this rule.  We still write code without underscored names, except in the case of explicitly ignored function arguments described above.

- `import/no-named-as-default`: Sometimes we want to provide a name for a default export so that the code is more “greppable”.

- `import/no-named-as-default-member`: This rule blocks the ability to export localized Redux selectors by name and globalized Redux selectors as the default export as described in [this blog post](http://randycoulman.com/blog/2016/09/27/modular-reducers-and-selectors/).

- `import/extensions`: We now require extensions for `scss` files to work properly with our create-react-app based boilerplate, [generator-react-zeal](https://github.com/CodingZeal/generator-react-zeal).

- `import/prefer-default-export`: We now disable this rule.  Often, we’ll create a file that will eventually have multiple named exports, but for now does not.  We now prefer the flexibility to choose between default and named exports on a case-by-case basis.

- `react/no-set-state`: While we still use Redux for most of our state management, there are cases when it makes more sense for a React component to maintain its own state.