### PR TITLE
Don't fail if missing-rules:* scripts fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   ],
   "scripts": {
     "missing-rules": "run-p missing-rules:*",
-    "missing-rules:core": "eslint-find-rules --unused",
-    "missing-rules:react": "eslint-find-rules --no-core --unused react.js",
-    "missing-rules:react-native": "eslint-find-rules --no-core --unused react-native.js",
+    "missing-rules:core": "eslint-find-rules --unused --no-error",
+    "missing-rules:react": "eslint-find-rules --no-core --unused --no-error react.js",
+    "missing-rules:react-native": "eslint-find-rules --no-core --unused --no-error react-native.js",
     "test": "eslint ."
   },
   "repository": {


### PR DESCRIPTION
`eslint-find-rules` currently reports deprecated rules as missing, and so exits with a non-zero exit code.  This behavior makes the current `missing-rules` npm script essentially useless.

For now, this adds the `—no-error` flag to all of the calls to eslint-find-rules so that they always exit cleanly.

Once https://github.com/sarbbottam/eslint-find-rules/issues/172 gets done, we should be able to revert this change.  We could even then include the `missing-rules` task in our CI validation suite, failing the build if there are missing rules.