### PR TITLE
Upgrade to eslint-plugin-react 6.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,13 +44,13 @@
     "eslint": "^3.15.0",
     "eslint-find-rules": "^1.14.3",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-react": "^6.9.0",
+    "eslint-plugin-react": "^6.10.0",
     "eslint-plugin-react-native": "^2.2.1",
     "npm-run-all": "^4.0.1"
   },
   "peerDependencies": {
     "babel-eslint": "^7.1.1",
-    "eslint": "^3.14.1",
+    "eslint": "^3.15.0",
     "eslint-plugin-import": "^2.2.0"
   }
 }

--- a/react.js
+++ b/react.js
@@ -11,6 +11,10 @@ module.exports = {
     'react/display-name': 'warn',
     // Forbid certain props on Components
     'react/forbid-component-props': 'off',
+    //  Forbid certain elements
+    'react/forbid-elements': 'off',
+    // Forbid foreign propTypes
+    'react/forbid-foreign-prop-types': 'off',
     // Forbid certain propTypes
     'react/forbid-prop-types': 'warn',
     // Enforce boolean attributes notation in JSX
@@ -121,6 +125,8 @@ module.exports = {
       requiredFirst: true
     }],
     // Enforce style prop value being an object
-    'react/style-prop-object': 'warn'
+    'react/style-prop-object': 'warn',
+    // Prevent void DOM elements (e.g. <img />, <br />) from receiving children
+    'react/void-dom-elements-no-children': 'warn'
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,10 +16,6 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.3.tgz#1a3e850b428e73ba6b09d1cc527f5aaad4d03ef1"
-
 ajv-keywords@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.1.1.tgz#02550bc605a3e576041565628af972e06c549d50"
@@ -433,13 +429,15 @@ eslint-plugin-react-native@^2.2.1:
     babel-eslint "7.1.1"
     eslint "3.12.0"
 
-eslint-plugin-react@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.9.0.tgz#54c2e9906b76f9d10142030bdc34e9d6840a0bb2"
+eslint-plugin-react@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.10.0.tgz#9c48b48d101554b5355413e7c64238abde6ef1ef"
   dependencies:
     array.prototype.find "^2.0.1"
     doctrine "^1.2.2"
+    has "^1.0.1"
     jsx-ast-utils "^1.3.4"
+    object.assign "^4.0.4"
 
 eslint-rule-documentation@^1.0.0:
   version "1.0.2"
@@ -523,14 +521,7 @@ eslint@^3.15.0:
     text-table "~0.2.0"
     user-home "^2.0.0"
 
-espree@^3.3.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.3.2.tgz#dbf3fadeb4ecb4d4778303e50103b3d36c88b89c"
-  dependencies:
-    acorn "^4.0.1"
-    acorn-jsx "^3.0.0"
-
-espree@^3.4.0:
+espree@^3.3.1, espree@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.0.tgz#41656fa5628e042878025ef467e78f125cb86e1d"
   dependencies:
@@ -985,9 +976,17 @@ object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
-object-keys@^1.0.8:
+object-keys@^1.0.10, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object.assign@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.0.4.tgz#b1c9cc044ef1b9fe63606fc141abbb32e14730cc"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.0"
+    object-keys "^1.0.10"
 
 once@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
Three new rules, but only one enabled:

- `react/forbid-foreign-proptypes`: Off because we don’t use propTypes, so we don’t need this rule.
- `react/forbid-proptypes`: Off because we don’t typically forbid things, but this could be used on a per-project basis to make sure that we use our own wrapper components when we have them.
- `react/void-dom-elements-no-children`: Warning because React will also warn us about this, and getting immediate feedback in the editor is faster.