### PR TITLE
Add missing-rules scripts to CI build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,4 +11,4 @@ dependencies:
     - yarn
 test:
   override:
-    - yarn test
+    - yarn validate

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "missing-rules:jest": "eslint-find-rules --no-core --unused jest.js",
     "missing-rules:react": "eslint-find-rules --no-core --unused --no-error react.js",
     "missing-rules:react-native": "eslint-find-rules --no-core --unused react-native.js",
-    "test": "eslint ."
+    "test": "eslint .",
+    "validate": "run-p test missing-rules"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Run the `missing-rules` scripts on CI as part of the tests.  That way, the build will fail if we forget to configure one or more rules.

Some of the `missing-rules` scripts don’t yet report errors due to deprecated rules, but when that issue is fixed upstream, this will become more useful.