### PR TITLE
Update to eslint-plugin-jest 20.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ This plugin contains all of the rules available in:
 * [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 6.10.3
 * [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native): 2.3.2
 * [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 2.2.0
-* [eslint-plugin-jest](https://github.com/jkimbo/eslint-plugin-jest): 19.0.1
+* [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest): 20.0.0
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint": "^3.19.0",
     "eslint-find-rules": "^1.14.3",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jest": "^19.0.1",
+    "eslint-plugin-jest": "^20.0.0",
     "eslint-plugin-react": "^6.10.3",
     "eslint-plugin-react-native": "^2.3.2",
     "npm-run-all": "^4.0.2"


### PR DESCRIPTION
In v0.20.0, we added configuration for the new rule `jest/valid-expect`.  However, that rule wasn’t added until babel-plugin-jest v20.0.0.

This PR updates our dependency to v20.0.0, and also fixes one of the links to babel-plugin-jest.