### PR TITLE
Add instructions for usage with prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ or, if your webpack config file is not in the default location:
 
 ## Usage With Prettier
 
-To use this configuration with [prettier](https://github.com/prettier/prettier), do the following:
+To use this configuration with [prettier](https://github.com/prettier/prettier), use [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) to override any conflicting rules:
 
 ```
 npm install eslint-config-prettier --save-dev

--- a/README.md
+++ b/README.md
@@ -109,6 +109,24 @@ or, if your webpack config file is not in the default location:
 }
 ```
 
+## Usage With Prettier
+
+To use this configuration with [prettier](https://github.com/prettier/prettier), do the following:
+
+```
+npm install eslint-config-prettier --save-dev
+```
+
+Then, in your `.eslintrc` file, extend the `prettier` (and `prettier/react`) configurations after any `zeal` configurations.  For example:
+
+```
+{
+  "extends": ["zeal", "zeal/react", "prettier", "prettier/react"]
+}
+```
+
+That way, the `prettier` configurations will override any `zeal` configurations that would otherwise conflict with prettier's formatting.
+
 ## Supported Versions
 
 This plugin contains all of the rules available in:


### PR DESCRIPTION
Update the README with instructions for using this configuration with prettier.

It turns out that we don't need to change anything; people can use [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) along with eslint-config-zeal to get the desired behavior.

Closes #62 