### PR TITLE
Update eslint-plugin-jest to version 21.15.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+yarn-error.log

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This plugin contains all of the rules available in:
 * [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 7.7.0
 * [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native): 3.2.1
 * [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 2.9.0
-* [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest): 21.12.2
+* [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest): 21.15.0
 
 ## License
 

--- a/jest.js
+++ b/jest.js
@@ -25,6 +25,8 @@ module.exports = {
     "jest/no-focused-tests": "warn",
     // Disallow setup and teardown hooks
     "jest/no-hooks": "off",
+    // Disallow importing jest
+    "jest/no-jest-import": "warn",
     // Disallow identical titles
     "jest/no-identical-title": "warn",
     // Disallow large snapshots

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-find-rules": "^3.2.1",
     "eslint-plugin-import": "2.9.0",
-    "eslint-plugin-jest": "21.12.2",
+    "eslint-plugin-jest": "21.15.0",
     "eslint-plugin-react": "7.7.0",
     "eslint-plugin-react-native": "3.2.1",
     "husky": "^0.14.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -829,9 +829,9 @@ eslint-plugin-import@2.9.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-eslint-plugin-jest@21.12.2:
-  version "21.12.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.12.2.tgz#325f7c6a5078aed51ea087c33c26792337b5ba37"
+eslint-plugin-jest@21.15.0:
+  version "21.15.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.15.0.tgz#645a3f560d3e61d99611b215adc80b4f31e6d896"
 
 eslint-plugin-react-native-globals@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
- Configure new rule `jest/no-jest-import` as a warning
- git-ignore `yarn-error.log`

Closes #97