### PR TITLE
⬆️ Upgrade dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,131 +8,131 @@ All notable changes to this project will be documented in this file. This projec
 
 ## Changed
 
-* Update to eslint 4.19.0 ([#98](https://github.com/CodingZeal/eslint-config-zeal/pull/98))
-* Update to eslint-plugin-jest 21.15.0 ([#99](https://github.com/CodingZeal/eslint-config-zeal/pull/99))
+- Update to eslint 4.19.0 ([#98](https://github.com/CodingZeal/eslint-config-zeal/pull/98))
+- Update to eslint-plugin-jest 21.15.0 ([#99](https://github.com/CodingZeal/eslint-config-zeal/pull/99))
 
 ## Added
 
-* New rule: `jest/no-jest-import` defaults to `warn` ([#99](https://github.com/CodingZeal/eslint-config-zeal/pull/99))
+- New rule: `jest/no-jest-import` defaults to `warn` ([#99](https://github.com/CodingZeal/eslint-config-zeal/pull/99))
 
 ## [1.4.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v1.3.0...v1.4.0) - 2018-03-02
 
 ### Changed
 
-* Update to eslint 4.18.1 ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* Update to eslint-plugin-import 2.9.0 ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* Update to eslint-plugin-jest 21.12.2 ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* Update to eslint-plugin-react 7.7.0 ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* Update to eslint-plugin-react-native 3.2.1 ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- Update to eslint 4.18.1 ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- Update to eslint-plugin-import 2.9.0 ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- Update to eslint-plugin-jest 21.12.2 ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- Update to eslint-plugin-react 7.7.0 ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- Update to eslint-plugin-react-native 3.2.1 ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
 
 ### Added
 
-* New rule: `import/no-self-import` defaults to `warn` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* New rule: `import/no-default-export` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* New rule: `import/group-exports` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* New rule: `import/no-useless-path-segments` defaults to `warn` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* New rule: `jest/consistent-test-it` defaults to `warn`; set to always use `test` and never `it` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* New rule: `jest/lowercase-name` defaults to `warn` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* New rule: `jest/no-hooks` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* New rule: `jest/no-test-prefixes` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* New rule: `jest/prefer-expect-assertions` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* New rule: `jest/valid-describe` defaults to `warn` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* New rule: `jest/valid-expect-in-promise` defaults to `warn` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* New rule: `react/forbid-dom-props` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* New rule: `react/jsx-child-element-spacing` defaults to `warn` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* New rule: `react/jsx-max-depth` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* New rule: `react/jsx-sort-default-props` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
-* New rule: `react/no-this-in-sfs` defaults to `warn` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `import/no-self-import` defaults to `warn` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `import/no-default-export` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `import/group-exports` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `import/no-useless-path-segments` defaults to `warn` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `jest/consistent-test-it` defaults to `warn`; set to always use `test` and never `it` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `jest/lowercase-name` defaults to `warn` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `jest/no-hooks` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `jest/no-test-prefixes` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `jest/prefer-expect-assertions` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `jest/valid-describe` defaults to `warn` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `jest/valid-expect-in-promise` defaults to `warn` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `react/forbid-dom-props` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `react/jsx-child-element-spacing` defaults to `warn` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `react/jsx-max-depth` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `react/jsx-sort-default-props` defaults to `off` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
+- New rule: `react/no-this-in-sfs` defaults to `warn` ([#94](https://github.com/CodingZeal/eslint-config-zeal/pull/94))
 
 ### Removed
 
-* Remove deprecated rule: `prefer-reflect` ([#91](https://github.com/CodingZeal/eslint-config-zeal/pull/91))
+- Remove deprecated rule: `prefer-reflect` ([#91](https://github.com/CodingZeal/eslint-config-zeal/pull/91))
 
 ### Internal
 
-* The `missing-rules` npm scripts now report when there are deprecated rules in use ([#91](https://github.com/CodingZeal/eslint-config-zeal/pull/91))
+- The `missing-rules` npm scripts now report when there are deprecated rules in use ([#91](https://github.com/CodingZeal/eslint-config-zeal/pull/91))
 
 ## [1.3.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v1.2.0...v1.3.0) - 2018-02-09
 
 ### Changed
 
-* Update to eslint 4.13.1 ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
-* Update to eslint-plugin-react 7.5.1 ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
-* Update to eslint-plugin-react-native 3.2.0 ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
-* Update to eslint-plugin-jest 21.5.0 ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
-* Update rule: `react/forbid-prop-types` adds `checkContextTypes: true` and `checkChildContextTypes: true` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
-* Update rule: `react/sort-prop-types` adds `sortShapeProp: true` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
+- Update to eslint 4.13.1 ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
+- Update to eslint-plugin-react 7.5.1 ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
+- Update to eslint-plugin-react-native 3.2.0 ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
+- Update to eslint-plugin-jest 21.5.0 ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
+- Update rule: `react/forbid-prop-types` adds `checkContextTypes: true` and `checkChildContextTypes: true` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
+- Update rule: `react/sort-prop-types` adds `sortShapeProp: true` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
 
 ### Added
 
-* New rule: `implicit-arrow-linebreak` defaults to `off` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
-* New rule: `jest/no-large-snapshots` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
-* New rule: `jest/prefer-to-have-length` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
-* New rule: `jest/prefer-to-be-null` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
-* New rule: `jest/prefer-to-be-undefined` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
-* New rule: `react/button-has-type` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
-* New rule: `react/destructuring-assignment` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
-* New rule: `react/no-access-state-in-setstate` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
-* New rule: `react/jsx-one-expression-per-line` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
+- New rule: `implicit-arrow-linebreak` defaults to `off` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
+- New rule: `jest/no-large-snapshots` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
+- New rule: `jest/prefer-to-have-length` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
+- New rule: `jest/prefer-to-be-null` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
+- New rule: `jest/prefer-to-be-undefined` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
+- New rule: `react/button-has-type` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
+- New rule: `react/destructuring-assignment` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
+- New rule: `react/no-access-state-in-setstate` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
+- New rule: `react/jsx-one-expression-per-line` defaults to `warn` ([#81](https://github.com/CodingZeal/eslint-config-zeal/pull/81))
 
 ## [1.2.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v1.1.0...v1.2.0) - 2018-02-09
 
 ### Changed
 
-* Update to eslint 4.9.0 ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
-* Update to eslint-plugin-react 7.4.0 ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
-* Update to eslint-plugin-import 2.8.0 ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
-* Update to eslint-plugin-jest 21.2.0 ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
-* Update to eslint-plugin-react-native 3.1.0 ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
-* Update to babel-eslint 8.0.1 ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
+- Update to eslint 4.9.0 ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
+- Update to eslint-plugin-react 7.4.0 ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
+- Update to eslint-plugin-import 2.8.0 ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
+- Update to eslint-plugin-jest 21.2.0 ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
+- Update to eslint-plugin-react-native 3.1.0 ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
+- Update to babel-eslint 8.0.1 ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
 
 ### Added
 
-* New rule: `function-paren-newline` defaults to `warn` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
-* New rule: `lines-between-class-members` defaults to `warn` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
-* New rule: `multiline-comment-style` defaults to `off` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
-* New rule: `import/exports-last` defaults to `off` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
-* New rule: `react/boolean-prop-naming` defaults to `off` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
-* New rule: `react/jsx-curly-brace-presence` defaults to `warn` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
-* New rule: `react/no-typos` defaults to `warn` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
-* New rule: `react/no-unused-state` defaults to `warn` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
+- New rule: `function-paren-newline` defaults to `warn` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
+- New rule: `lines-between-class-members` defaults to `warn` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
+- New rule: `multiline-comment-style` defaults to `off` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
+- New rule: `import/exports-last` defaults to `off` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
+- New rule: `react/boolean-prop-naming` defaults to `off` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
+- New rule: `react/jsx-curly-brace-presence` defaults to `warn` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
+- New rule: `react/no-typos` defaults to `warn` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
+- New rule: `react/no-unused-state` defaults to `warn` ([#79](https://github.com/CodingZeal/eslint-config-zeal/pull/79))
 
 ## [1.1.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v1.0.1...v1.1.0) - 2017-07-14
 
 ### Changed
 
-* Update to eslint 4.2.0 ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69), [#71](https://github.com/CodingZeal/eslint-config-zeal/pull/71))
-* Update to eslint-find-rules 3.1.1 ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
-* Update to eslint-plugin-import 2.7.0 ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69), [#70](https://github.com/CodingZeal/eslint-config-zeal/pull/70))
-* Update to eslint-plugin-jest 20.0.3 ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
-* Update to eslint-plugin-react 7.1.0 ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- Update to eslint 4.2.0 ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69), [#71](https://github.com/CodingZeal/eslint-config-zeal/pull/71))
+- Update to eslint-find-rules 3.1.1 ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- Update to eslint-plugin-import 2.7.0 ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69), [#70](https://github.com/CodingZeal/eslint-config-zeal/pull/70))
+- Update to eslint-plugin-jest 20.0.3 ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- Update to eslint-plugin-react 7.1.0 ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
 
 ### Added
 
-* New rule: `for-direction` defaults to `warn` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
-* New rule: `getter-return` defaults to `warn` ([#71](https://github.com/CodingZeal/eslint-config-zeal/pull/71))
-* New rule: `no-buffer-constructor` defaults to `warn` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
-* New rule: `array-bracket-newline` defaults to `off` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
-* New rule: `array-element-newline` defaults to `off` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
-* New rule: `padding-line-between-statements` configures line breaks after vars and around directives ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
-* New rule: `semi-style` defaults to `warn` if they are not at end of line ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
-* New rule: `switch-colon-spacing` defaults to `warn` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
-* New rule: `import/no-anonymous-default-export` defaults to `off` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
-* New rule: `react/default-props-match-prop-types` defaults to `off` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
-* New rule: `react/jsx-closing-tag-location` defaults to `warn` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
-* New rule: `react/no-redundant-should-component-update` defaults to `warn` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- New rule: `for-direction` defaults to `warn` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- New rule: `getter-return` defaults to `warn` ([#71](https://github.com/CodingZeal/eslint-config-zeal/pull/71))
+- New rule: `no-buffer-constructor` defaults to `warn` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- New rule: `array-bracket-newline` defaults to `off` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- New rule: `array-element-newline` defaults to `off` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- New rule: `padding-line-between-statements` configures line breaks after vars and around directives ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- New rule: `semi-style` defaults to `warn` if they are not at end of line ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- New rule: `switch-colon-spacing` defaults to `warn` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- New rule: `import/no-anonymous-default-export` defaults to `off` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- New rule: `react/default-props-match-prop-types` defaults to `off` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- New rule: `react/jsx-closing-tag-location` defaults to `warn` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- New rule: `react/no-redundant-should-component-update` defaults to `warn` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
 
 ### Removed
 
-* Deprecated rule: `lines-around-directive` covered by `padding-line-between-statements` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
-* Deprecated rule: `newline-after-var` covered by `padding-line-between-statements` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
-* Deprecated rule: `newline-before-return` covered by `padding-line-between-statements` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- Deprecated rule: `lines-around-directive` covered by `padding-line-between-statements` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- Deprecated rule: `newline-after-var` covered by `padding-line-between-statements` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
+- Deprecated rule: `newline-before-return` covered by `padding-line-between-statements` ([#69](https://github.com/CodingZeal/eslint-config-zeal/pull/69))
 
 ## [1.0.1](https://github.com/CodingZeal/eslint-config-zeal/compare/v1.0.0...v1.0.1) - 2017-06-27
 
 ### Fixed
 
-* Update peer dependencies to allow new major versions for flexibility - @cthorner ([#67](https://github.com/CodingZeal/eslint-config-zeal/pull/67))
+- Update peer dependencies to allow new major versions for flexibility - @cthorner ([#67](https://github.com/CodingZeal/eslint-config-zeal/pull/67))
 
 ## [1.0.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.21.0...v1.0.0) - 2017-05-17
 
@@ -142,316 +142,316 @@ Releasing 0.21.0 as 1.0.0 with only minor README changes.
 
 ### Changed
 
-* Update to eslint-plugin-react 7.0.1. ([#59](https://github.com/CodingZeal/eslint-config-zeal/pull/59))
+- Update to eslint-plugin-react 7.0.1. ([#59](https://github.com/CodingZeal/eslint-config-zeal/pull/59))
 
-* Use default configuration for the `react/jsx-first-prop-new-line` rule (`multiline-multiprop`) instead of `mutliline` as the default configuration better reflects what we want: a single property that spans multiple lines can start on the same line as the component name. ([#59](https://github.com/CodingZeal/eslint-config-zeal/pull/59))
+- Use default configuration for the `react/jsx-first-prop-new-line` rule (`multiline-multiprop`) instead of `mutliline` as the default configuration better reflects what we want: a single property that spans multiple lines can start on the same line as the component name. ([#59](https://github.com/CodingZeal/eslint-config-zeal/pull/59))
 
 ### Added
 
-* Enables warnings for new rule: `react/no-will-update-set-state` ([#59](https://github.com/CodingZeal/eslint-config-zeal/pull/59))
+- Enables warnings for new rule: `react/no-will-update-set-state` ([#59](https://github.com/CodingZeal/eslint-config-zeal/pull/59))
 
 ### Removed
 
-* Removes configuration for deprecated rule: `react/jsx-space-before-closing`. Its behavior is already checked by our configuration of `react/jsx-tag-spacing`.
+- Removes configuration for deprecated rule: `react/jsx-space-before-closing`. Its behavior is already checked by our configuration of `react/jsx-tag-spacing`.
   ([#59](https://github.com/CodingZeal/eslint-config-zeal/pull/59))
 
 ## [0.20.2](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.20.1...v0.20.2) - 2017-05-10
 
 ### Changed
 
-* Update to eslint-plugin-jest 20.0.0. ([#60](https://github.com/CodingZeal/eslint-config-zeal/pull/60))
+- Update to eslint-plugin-jest 20.0.0. ([#60](https://github.com/CodingZeal/eslint-config-zeal/pull/60))
 
 ### Fixed
 
-* Resolve `Definition for rule 'jest/valid-expect' was not found` error. That rule was added in eslint-plugin-jest 20.0.0, but we added a definition for it in v0.20.0. We now depend on the correct version of eslint-plugin-jest, so the error no longer occurs. ([#60](https://github.com/CodingZeal/eslint-config-zeal/pull/60))
+- Resolve `Definition for rule 'jest/valid-expect' was not found` error. That rule was added in eslint-plugin-jest 20.0.0, but we added a definition for it in v0.20.0. We now depend on the correct version of eslint-plugin-jest, so the error no longer occurs. ([#60](https://github.com/CodingZeal/eslint-config-zeal/pull/60))
 
 ## [0.20.1](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.20.0...v0.20.1) - 2017-05-05
 
 ### Changed
 
-* Update to ESLint 3.19.0. ([#56](https://github.com/CodingZeal/eslint-config-zeal/pull/56))
+- Update to ESLint 3.19.0. ([#56](https://github.com/CodingZeal/eslint-config-zeal/pull/56))
 
-* Update to eslint-plugin-react 6.10.3. ([#56](https://github.com/CodingZeal/eslint-config-zeal/pull/56))
+- Update to eslint-plugin-react 6.10.3. ([#56](https://github.com/CodingZeal/eslint-config-zeal/pull/56))
 
-* Update to eslint-plugin-react-native 2.3.2. ([#56](https://github.com/CodingZeal/eslint-config-zeal/pull/56))
+- Update to eslint-plugin-react-native 2.3.2. ([#56](https://github.com/CodingZeal/eslint-config-zeal/pull/56))
 
-* Update to use babel-eslint 7.2.3. ([#56](https://github.com/CodingZeal/eslint-config-zeal/pull/56))
+- Update to use babel-eslint 7.2.3. ([#56](https://github.com/CodingZeal/eslint-config-zeal/pull/56))
 
 ## [0.20.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.19.0...v0.20.0) - 2017-03-17
 
 ### Changed
 
-* Update to ESLint 3.17.1. ([#53](https://github.com/CodingZeal/eslint-config-zeal/pull/53))
+- Update to ESLint 3.17.1. ([#53](https://github.com/CodingZeal/eslint-config-zeal/pull/53))
 
-* Update to eslint-plugin-react-native 2.3.1. ([#53](https://github.com/CodingZeal/eslint-config-zeal/pull/53))
+- Update to eslint-plugin-react-native 2.3.1. ([#53](https://github.com/CodingZeal/eslint-config-zeal/pull/53))
 
-* Update to eslint-plugin-jest 19.0.1. ([#53](https://github.com/CodingZeal/eslint-config-zeal/pull/53))
+- Update to eslint-plugin-jest 19.0.1. ([#53](https://github.com/CodingZeal/eslint-config-zeal/pull/53))
 
-* Adjust for renamed rule: `jest/no-exclusive-tests` is now `jest/no-focused-tests`. ([#53](https://github.com/CodingZeal/eslint-config-zeal/pull/53))
+- Adjust for renamed rule: `jest/no-exclusive-tests` is now `jest/no-focused-tests`. ([#53](https://github.com/CodingZeal/eslint-config-zeal/pull/53))
 
 ### Added
 
-* Enables warnings for new rules: `no-compare-neg-zero`, `nonblock-statement-body-position`, `jest/no-disabled-tests`, and `jest/valid-expect`. ([#53](https://github.com/CodingZeal/eslint-config-zeal/pull/53))
+- Enables warnings for new rules: `no-compare-neg-zero`, `nonblock-statement-body-position`, `jest/no-disabled-tests`, and `jest/valid-expect`. ([#53](https://github.com/CodingZeal/eslint-config-zeal/pull/53))
 
 ## [0.19.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.18.0...v0.19.0) - 2017-02-17
 
 ### Changed
 
-* Update to ESLint 3.15.0. ([#50](https://github.com/CodingZeal/eslint-config-zeal/pull/50))
+- Update to ESLint 3.15.0. ([#50](https://github.com/CodingZeal/eslint-config-zeal/pull/50))
 
-* Update to eslint-plugin-react 6.10.0. ([#52](https://github.com/CodingZeal/eslint-config-zeal/pull/52))
+- Update to eslint-plugin-react 6.10.0. ([#52](https://github.com/CodingZeal/eslint-config-zeal/pull/52))
 
 ### Added
 
-* Enables warnings for new rules: `template-tag-spacing` and `react/void-dom-elements-no-children`. ([#50](https://github.com/CodingZeal/eslint-config-zeal/pull/50), [#52](https://github.com/CodingZeal/eslint-config-zeal/pull/52))
+- Enables warnings for new rules: `template-tag-spacing` and `react/void-dom-elements-no-children`. ([#50](https://github.com/CodingZeal/eslint-config-zeal/pull/50), [#52](https://github.com/CodingZeal/eslint-config-zeal/pull/52))
 
-* Adds support for new rules, but leaves them disabled: `react/forbid-elements` and `react/forbid-foreign-prop-types`. ([#52](https://github.com/CodingZeal/eslint-config-zeal/pull/52))
+- Adds support for new rules, but leaves them disabled: `react/forbid-elements` and `react/forbid-foreign-prop-types`. ([#52](https://github.com/CodingZeal/eslint-config-zeal/pull/52))
 
 ## [0.18.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.17.0...v0.18.0) - 2017-01-27
 
 ### Changed
 
-* Update to ESLint 3.14.1. ([#49](https://github.com/CodingZeal/eslint-config-zeal/pull/49))
+- Update to ESLint 3.14.1. ([#49](https://github.com/CodingZeal/eslint-config-zeal/pull/49))
 
 ### Added
 
-* Adds support for new rule, but leaves them disabled: `prefer-promise-reject-errors` and `no-multi-assign`. ([#49](https://github.com/CodingZeal/eslint-config-zeal/pull/49))
+- Adds support for new rule, but leaves them disabled: `prefer-promise-reject-errors` and `no-multi-assign`. ([#49](https://github.com/CodingZeal/eslint-config-zeal/pull/49))
 
 ## [0.17.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.16.0...v0.17.0) - 2017-01-23
 
 ### Changed
 
-* Update rule configuration to match our (Zeal's) current practice ([#48](https://github.com/CodingZeal/eslint-config-zeal/pull/48)):
+- Update rule configuration to match our (Zeal's) current practice ([#48](https://github.com/CodingZeal/eslint-config-zeal/pull/48)):
 
-  * `complexity`: Change maximum allowed complexity from 2 to 3. We knew 2 was probably too low when we started, but we didn’t know how big to make it. After some experience, we now think 3 is pretty good for most of our projects. We’ll use comments to bump the level up on a case-by-case basis where needed. We rarely write code that needs more than 4.
+  - `complexity`: Change maximum allowed complexity from 2 to 3. We knew 2 was probably too low when we started, but we didn’t know how big to make it. After some experience, we now think 3 is pretty good for most of our projects. We’ll use comments to bump the level up on a case-by-case basis where needed. We rarely write code that needs more than 4.
 
-  * `no-invalid-this`: This rule doesn’t yet properly support class property syntax, so we disable it in almost all of our projects.
+  - `no-invalid-this`: This rule doesn’t yet properly support class property syntax, so we disable it in almost all of our projects.
 
-  * `no-unused-expressions`: We often relax this rule to allow short-circuiting (`someCondition && someAction()`) or ternary expressions (`return someCondition ? someAction() : null`).
+  - `no-unused-expressions`: We often relax this rule to allow short-circuiting (`someCondition && someAction()`) or ternary expressions (`return someCondition ? someAction() : null`).
 
-  * `no-unused-vars`: Add an `argsIgnorePattern` to allow us to use `_unusedVar` when we want to explicitly name an unused function argument. This is made possible by the change to `no-underscore-dangle`.
+  - `no-unused-vars`: Add an `argsIgnorePattern` to allow us to use `_unusedVar` when we want to explicitly name an unused function argument. This is made possible by the change to `no-underscore-dangle`.
 
-  * `no-underscore-dangle`: There are cases, such as when working with third-party software, that underscores are required, so we now disable this rule. We still write code without underscored names, except in the case of explicitly ignored function arguments described above.
+  - `no-underscore-dangle`: There are cases, such as when working with third-party software, that underscores are required, so we now disable this rule. We still write code without underscored names, except in the case of explicitly ignored function arguments described above.
 
-  * `import/no-named-as-default`: Sometimes we want to provide a name for a default export so that the code is more “greppable”.
+  - `import/no-named-as-default`: Sometimes we want to provide a name for a default export so that the code is more “greppable”.
 
-  * `import/no-named-as-default-member`: We now disable this rule because it blocks the ability to export localized Redux selectors by name and globalized Redux selectors as the default export as described in [this blog post](http://randycoulman.com/blog/2016/09/27/modular-reducers-and-selectors/).
+  - `import/no-named-as-default-member`: We now disable this rule because it blocks the ability to export localized Redux selectors by name and globalized Redux selectors as the default export as described in [this blog post](http://randycoulman.com/blog/2016/09/27/modular-reducers-and-selectors/).
 
-  * `import/extensions`: We now require extensions for `scss` files to work properly with our create-react-app based boilerplate, [generator-react-zeal](https://github.com/CodingZeal/generator-react-zeal).
+  - `import/extensions`: We now require extensions for `scss` files to work properly with our create-react-app based boilerplate, [generator-react-zeal](https://github.com/CodingZeal/generator-react-zeal).
 
-  * `import/prefer-default-export`: We now disable this rule. Often, we’ll create a file that will eventually have multiple named exports, but for now does not. We now prefer the flexibility to choose between default and named exports on a case-by-case basis.
+  - `import/prefer-default-export`: We now disable this rule. Often, we’ll create a file that will eventually have multiple named exports, but for now does not. We now prefer the flexibility to choose between default and named exports on a case-by-case basis.
 
-  * `react/no-set-state`: We now disable this rule. While we still use Redux for most of our state management, there are cases when it makes more sense for a React component to maintain its own state.
+  - `react/no-set-state`: We now disable this rule. While we still use Redux for most of our state management, there are cases when it makes more sense for a React component to maintain its own state.
 
-* Update to ESLint 3.13.1 ([#46](https://github.com/CodingZeal/eslint-config-zeal/pull/46))
+- Update to ESLint 3.13.1 ([#46](https://github.com/CodingZeal/eslint-config-zeal/pull/46))
 
 ## [0.16.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.15.0...v0.16.0) - 2017-01-09
 
 ### Changed
 
-* Modify published package to include only necessary files. ([#41](https://github.com/CodingZeal/eslint-config-zeal/pull/41))
+- Modify published package to include only necessary files. ([#41](https://github.com/CodingZeal/eslint-config-zeal/pull/41))
 
-* Update to ESLint 3.13.0 and eslint-plugin-react 6.9.0 ([#45](https://github.com/CodingZeal/eslint-config-zeal/pull/45))
+- Update to ESLint 3.13.0 and eslint-plugin-react 6.9.0 ([#45](https://github.com/CodingZeal/eslint-config-zeal/pull/45))
 
 ### Added
 
-* Adds a configuration for [Jest](http://facebook.github.io/jest/), including the use of [eslint-plugin-jest](https://github.com/jkimbo/eslint-plugin-jest). ([#42](https://github.com/CodingZeal/eslint-config-zeal/pull/42))
+- Adds a configuration for [Jest](http://facebook.github.io/jest/), including the use of [eslint-plugin-jest](https://github.com/jkimbo/eslint-plugin-jest). ([#42](https://github.com/CodingZeal/eslint-config-zeal/pull/42))
 
-* Enables warning for new rule: `prefer-destructuring` ([#45](https://github.com/CodingZeal/eslint-config-zeal/pull/45))
+- Enables warning for new rule: `prefer-destructuring` ([#45](https://github.com/CodingZeal/eslint-config-zeal/pull/45))
 
 ## [0.15.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.14.1...v0.15.0) - 2016-12-16
 
 ### Changed
 
-* Update to ESLint 3.12.2, eslint-plugin-react 6.8.0, and eslint-plugin-react-native 2.2.1. ([#39](https://github.com/CodingZeal/eslint-config-zeal/pull/39))
+- Update to ESLint 3.12.2, eslint-plugin-react 6.8.0, and eslint-plugin-react-native 2.2.1. ([#39](https://github.com/CodingZeal/eslint-config-zeal/pull/39))
 
 ### Added
 
-* Enables warnings for new rules: `no-await-in-loop` and `react/no-array-index-key`. ([#39](https://github.com/CodingZeal/eslint-config-zeal/pull/39))
+- Enables warnings for new rules: `no-await-in-loop` and `react/no-array-index-key`. ([#39](https://github.com/CodingZeal/eslint-config-zeal/pull/39))
 
-* Adds support for new rule, but leaves it disabled: `react/require-default-props`. ([#39](https://github.com/CodingZeal/eslint-config-zeal/pull/39))
+- Adds support for new rule, but leaves it disabled: `react/require-default-props`. ([#39](https://github.com/CodingZeal/eslint-config-zeal/pull/39))
 
 ## [0.14.1](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.14.0...v0.14.1) - 2016-12-02
 
 ### Fixed
 
-* Fixed peer dependency on babel-eslint. Now 7.1.1.
+- Fixed peer dependency on babel-eslint. Now 7.1.1.
 
 ## [0.14.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.13.0...v0.14.0) - 2016-12-02
 
 ### Changed
 
-* Update to ESLint 3.11.1, eslint-plugin-react 6.7.1, eslint-plugin-react-native 2.2.0, and babel-eslint 7.1.1. ([#38](https://github.com/CodingZeal/eslint-config-zeal/pull/38))
+- Update to ESLint 3.11.1, eslint-plugin-react 6.7.1, eslint-plugin-react-native 2.2.0, and babel-eslint 7.1.1. ([#38](https://github.com/CodingZeal/eslint-config-zeal/pull/38))
 
-* Configure several rules as errors instead of warnings. These rules are ones that have a high probability of causing programs to fail, so getting fast feedback about these issues is important. Rules that are now errors: `no-dupe-args`, `no-dupe-keys`, `no-duplicate-case`, `no-redeclare`, `no-undef`, `import/no-unresolved`, and `import/named`. ([#37](https://github.com/CodingZeal/eslint-config-zeal/pull/37))
+- Configure several rules as errors instead of warnings. These rules are ones that have a high probability of causing programs to fail, so getting fast feedback about these issues is important. Rules that are now errors: `no-dupe-args`, `no-dupe-keys`, `no-duplicate-case`, `no-redeclare`, `no-undef`, `import/no-unresolved`, and `import/named`. ([#37](https://github.com/CodingZeal/eslint-config-zeal/pull/37))
 
 ### Added
 
-* Enables warnings for new rules: `require-await`, `react/jsx-tag-spacing`, `func-name-matching`, and `import/no-named-default`. ([#38](https://github.com/CodingZeal/eslint-config-zeal/pull/38))
+- Enables warnings for new rules: `require-await`, `react/jsx-tag-spacing`, `func-name-matching`, and `import/no-named-default`. ([#38](https://github.com/CodingZeal/eslint-config-zeal/pull/38))
 
-* Adds support for new rule, but leaves it disabled: `capitalized-comments`. ([#38](https://github.com/CodingZeal/eslint-config-zeal/pull/38))
+- Adds support for new rule, but leaves it disabled: `capitalized-comments`. ([#38](https://github.com/CodingZeal/eslint-config-zeal/pull/38))
 
 ## [0.13.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.12.1...v0.13.0) - 2016-11-14
 
 ### Changed
 
-* Update to ESLint 3.10.0, eslint-plugin-import 2.2.0, eslint-plugin-react 6.6.0, and babel-eslint 7.1.0. ([#36](https://github.com/CodingZeal/eslint-config-zeal/pull/36))
+- Update to ESLint 3.10.0, eslint-plugin-import 2.2.0, eslint-plugin-react 6.6.0, and babel-eslint 7.1.0. ([#36](https://github.com/CodingZeal/eslint-config-zeal/pull/36))
 
 ### Added
 
-* Enables warnings for new rules: `no-return-await`, `no-useless-return`, `func-name-matching`, and `import/no-named-default`. ([#36](https://github.com/CodingZeal/eslint-config-zeal/pull/36))
+- Enables warnings for new rules: `no-return-await`, `no-useless-return`, `func-name-matching`, and `import/no-named-default`. ([#36](https://github.com/CodingZeal/eslint-config-zeal/pull/36))
 
 ## [0.12.1](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.12.0...v0.12.1) - 2016-10-03
 
 ### Changed
 
-* Update to eslint-plugin-react 6.4.0. ([#34](https://github.com/CodingZeal/eslint-config-zeal/pull/34))
+- Update to eslint-plugin-react 6.4.0. ([#34](https://github.com/CodingZeal/eslint-config-zeal/pull/34))
 
 ## [0.12.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.11.0...v0.12.0) - 2016-10-03
 
 ### Changed
 
-* Update to ESLint 3.7.0, eslint-plugin-import 2.0.0, and babel-eslint 7.0.0. ([#33](https://github.com/CodingZeal/eslint-config-zeal/pull/33))
+- Update to ESLint 3.7.0, eslint-plugin-import 2.0.0, and babel-eslint 7.0.0. ([#33](https://github.com/CodingZeal/eslint-config-zeal/pull/33))
 
-* Change `ecmaVersion` setting to `2017` to get support for ES2017 features like `async`/`await`. ([#33](https://github.com/CodingZeal/eslint-config-zeal/pull/33))
+- Change `ecmaVersion` setting to `2017` to get support for ES2017 features like `async`/`await`. ([#33](https://github.com/CodingZeal/eslint-config-zeal/pull/33))
 
-* Rename `import/import-first` to `import/first`. ([#33](https://github.com/CodingZeal/eslint-config-zeal/pull/33))
+- Rename `import/import-first` to `import/first`. ([#33](https://github.com/CodingZeal/eslint-config-zeal/pull/33))
 
 ### Added
 
-* Enables warnings for new rules: `import/no-dynamic-require` and `import/no-webpack-loader-syntax`. ([#33](https://github.com/CodingZeal/eslint-config-zeal/pull/33))
+- Enables warnings for new rules: `import/no-dynamic-require` and `import/no-webpack-loader-syntax`. ([#33](https://github.com/CodingZeal/eslint-config-zeal/pull/33))
 
-* Adds support for new rules, but leaves them disabled: `import/no-internal-modules`, `import/unambiguous`, and `import/no-unassigned-import`. ([#33](https://github.com/CodingZeal/eslint-config-zeal/pull/33))
+- Adds support for new rules, but leaves them disabled: `import/no-internal-modules`, `import/unambiguous`, and `import/no-unassigned-import`. ([#33](https://github.com/CodingZeal/eslint-config-zeal/pull/33))
 
 ## [0.11.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.10.0...v0.11.0) - 2016-09-20
 
 ### Changed
 
-* Update to ESLint 3.5.0, eslint-plugin-react 6.3.0, and eslint-plugin-import 1.15.0. ([#30](https://github.com/CodingZeal/eslint-config-zeal/pull/30))
+- Update to ESLint 3.5.0, eslint-plugin-react 6.3.0, and eslint-plugin-import 1.15.0. ([#30](https://github.com/CodingZeal/eslint-config-zeal/pull/30))
 
 ### Added
 
-* Enables warnings for new rules: `lines-around-directive`, `prefer-numeric-literals`, `symbol-description`, `import/no-absolute-path`, `react/no-children-prop`, `react/no-unescaped-entities`, `react/no-unused-prop-types`, and `react/style-prop-object`. ([#30](https://github.com/CodingZeal/eslint-config-zeal/pull/30))
+- Enables warnings for new rules: `lines-around-directive`, `prefer-numeric-literals`, `symbol-description`, `import/no-absolute-path`, `react/no-children-prop`, `react/no-unescaped-entities`, `react/no-unused-prop-types`, and `react/style-prop-object`. ([#30](https://github.com/CodingZeal/eslint-config-zeal/pull/30))
 
-* Adds support for new rules, but leaves them disabled: `class-methods-use-this`, `line-comment-position`, `no-restricted-properties`, and `import/max-dependencies`. ([#30](https://github.com/CodingZeal/eslint-config-zeal/pull/30))
+- Adds support for new rules, but leaves them disabled: `class-methods-use-this`, `line-comment-position`, `no-restricted-properties`, and `import/max-dependencies`. ([#30](https://github.com/CodingZeal/eslint-config-zeal/pull/30))
 
 ## [0.10.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.9.0...v0.10.0) - 2016-08-17
 
 ### Changed
 
-* Update to eslint-plugin-react 6.1.2. ([#28](https://github.com/CodingZeal/eslint-config-zeal/pull/28))
+- Update to eslint-plugin-react 6.1.2. ([#28](https://github.com/CodingZeal/eslint-config-zeal/pull/28))
 
-* Enable a warning for the `react/no-danger-with-children` rule. This rule was disabled when it was first added due to an issue in eslint-plugin-react 6.1.1. Version 6.1.2 fixes the issue, so the rule is now enabled as a warning. ([#28](https://github.com/CodingZeal/eslint-config-zeal/pull/28))
+- Enable a warning for the `react/no-danger-with-children` rule. This rule was disabled when it was first added due to an issue in eslint-plugin-react 6.1.1. Version 6.1.2 fixes the issue, so the rule is now enabled as a warning. ([#28](https://github.com/CodingZeal/eslint-config-zeal/pull/28))
 
 ## [0.9.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.8.1...v0.9.0) - 2016-08-16
 
 ### Added
 
-* Enables warnings for new rules: `no-template-curly-in-string`, `no-tabs`, `react/no-danger-with-children` (temporarily disabled; see [#26](https://github.com/CodingZeal/eslint-config-zeal/issues/26)), and `react/no-find-dom-node`. ([#23](https://github.com/CodingZeal/eslint-config-zeal/pull/23))
+- Enables warnings for new rules: `no-template-curly-in-string`, `no-tabs`, `react/no-danger-with-children` (temporarily disabled; see [#26](https://github.com/CodingZeal/eslint-config-zeal/issues/26)), and `react/no-find-dom-node`. ([#23](https://github.com/CodingZeal/eslint-config-zeal/pull/23))
 
-* Adds support for new rules, but leaves them disabled: `multiline-ternary`, `sort-keys`, `react/forbid-component-props`, and `import/no-restricted-paths`. ([#23](https://github.com/CodingZeal/eslint-config-zeal/pull/23))
+- Adds support for new rules, but leaves them disabled: `multiline-ternary`, `sort-keys`, `react/forbid-component-props`, and `import/no-restricted-paths`. ([#23](https://github.com/CodingZeal/eslint-config-zeal/pull/23))
 
-* Adds support for react-native ([#25](https://github.com/CodingZeal/eslint-config-zeal/pull/25), [#27](https://github.com/CodingZeal/eslint-config-zeal/pull/27))
+- Adds support for react-native ([#25](https://github.com/CodingZeal/eslint-config-zeal/pull/25), [#27](https://github.com/CodingZeal/eslint-config-zeal/pull/27))
 
 ### Changed
 
-* Update to ESLint 3.3.1, eslint-plugin-react 6.1.1, and eslint-plugin-import 1.13.0. ([#23](https://github.com/CodingZeal/eslint-config-zeal/pull/23))
+- Update to ESLint 3.3.1, eslint-plugin-react 6.1.1, and eslint-plugin-import 1.13.0. ([#23](https://github.com/CodingZeal/eslint-config-zeal/pull/23))
 
-* Replace deprecated rules with their replacements: ([#23](https://github.com/CodingZeal/eslint-config-zeal/pull/23))
-  * `no-negated-in-lhs` => `no-unsafe-negation`
-  * `no-native-reassign` => `no-global-assign`
-  * `no-spaced-func` => `func-call-spacing`
-  * `react/wrap-multilines` => `react/jsx-wrap-multilines`
-  * `react/no-comment-textnodes` => `react/jsx-no-comment-textnodes`
-  * `react/no-comment-textnodes` => `react/jsx-no-comment-textnodes`
+- Replace deprecated rules with their replacements: ([#23](https://github.com/CodingZeal/eslint-config-zeal/pull/23))
+  - `no-negated-in-lhs` => `no-unsafe-negation`
+  - `no-native-reassign` => `no-global-assign`
+  - `no-spaced-func` => `func-call-spacing`
+  - `react/wrap-multilines` => `react/jsx-wrap-multilines`
+  - `react/no-comment-textnodes` => `react/jsx-no-comment-textnodes`
+  - `react/no-comment-textnodes` => `react/jsx-no-comment-textnodes`
 
 ### Removed
 
-* Removed configuration for deprecated rule `react/require-extension`. ([#23](https://github.com/CodingZeal/eslint-config-zeal/pull/23))
+- Removed configuration for deprecated rule `react/require-extension`. ([#23](https://github.com/CodingZeal/eslint-config-zeal/pull/23))
 
 ## [0.8.1](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.8.0...v0.8.1) - 2016-07-19
 
 ### Changed
 
-* Mark `expect` as a global when using Chai. Some test runner configurations (such as with Karma) make `expect` available globally. By marking `expect` as a global, we don't get warnings from the `no-undef` rule. ([#21](https://github.com/CodingZeal/eslint-config-zeal/pull/21))
+- Mark `expect` as a global when using Chai. Some test runner configurations (such as with Karma) make `expect` available globally. By marking `expect` as a global, we don't get warnings from the `no-undef` rule. ([#21](https://github.com/CodingZeal/eslint-config-zeal/pull/21))
 
-* Don't report `no-mixed-operators` warnings for arithmetic expressions, while continuing to report them for logical, comparison, and bit-wise expressions. Most people understand the standard precedence of arithmetic operators and those expressions are more readable without the extra parentheses. ([#20](https://github.com/CodingZeal/eslint-config-zeal/pull/20))
+- Don't report `no-mixed-operators` warnings for arithmetic expressions, while continuing to report them for logical, comparison, and bit-wise expressions. Most people understand the standard precedence of arithmetic operators and those expressions are more readable without the extra parentheses. ([#20](https://github.com/CodingZeal/eslint-config-zeal/pull/20))
 
 ## [0.8.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.7.0...v0.8.0) - 2016-06-20
 
 ### Added
 
-* Enables warnings for new rules: `no-prototype-builtins`, `no-mixed-operators`, `unicode-bom`, `no-useless-rename`, `rest-spread-spacing`, `react/no-comment-textnodes`, and `react/no-render-return-value`. ([#18](https://github.com/CodingZeal/eslint-config-zeal/pull/18))
+- Enables warnings for new rules: `no-prototype-builtins`, `no-mixed-operators`, `unicode-bom`, `no-useless-rename`, `rest-spread-spacing`, `react/no-comment-textnodes`, and `react/no-render-return-value`. ([#18](https://github.com/CodingZeal/eslint-config-zeal/pull/18))
 
-* Adds support for new rules, but leaves them disabled: `max-lines`, `object-curly-newline`, `react/jsx-filename-extension`, and `react/require-optimization`. ([#18](https://github.com/CodingZeal/eslint-config-zeal/pull/18))
+- Adds support for new rules, but leaves them disabled: `max-lines`, `object-curly-newline`, `react/jsx-filename-extension`, and `react/require-optimization`. ([#18](https://github.com/CodingZeal/eslint-config-zeal/pull/18))
 
 ### Changed
 
-* Update to ESLint 2.13.1 and eslint-plugin-react 5.2.2. ([#18](https://github.com/CodingZeal/eslint-config-zeal/pull/18))
+- Update to ESLint 2.13.1 and eslint-plugin-react 5.2.2. ([#18](https://github.com/CodingZeal/eslint-config-zeal/pull/18))
 
 ## [0.7.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.6.2...v0.7.0) - 2016-05-27
 
 ### Added
 
-* Enables warnings for new rules: `no-unsafe-finally`, `no-useless-escape`, `no-duplicate-imports`, `no-useless-computed-key`, `import/no-named-as-default-member`, `import-no-deprecated`, `import/no-extraneous-dependencies`, `import/no-mutable-exports`, `import/no-duplicates`, `import/extensions`, `import/newline-after-import`, and `import/prefer-default-export`. ([#17](https://github.com/CodingZeal/eslint-config-zeal/pull/17))
+- Enables warnings for new rules: `no-unsafe-finally`, `no-useless-escape`, `no-duplicate-imports`, `no-useless-computed-key`, `import/no-named-as-default-member`, `import-no-deprecated`, `import/no-extraneous-dependencies`, `import/no-mutable-exports`, `import/no-duplicates`, `import/extensions`, `import/newline-after-import`, and `import/prefer-default-export`. ([#17](https://github.com/CodingZeal/eslint-config-zeal/pull/17))
 
-* Adds support for new rules, but leaves them disabled: `max-statements-per-line`, `object-property-newline`, `import/no-nodejs-modules`, `import/no-namespace`, and `import/order`. ([#17](https://github.com/CodingZeal/eslint-config-zeal/pull/17))
+- Adds support for new rules, but leaves them disabled: `max-statements-per-line`, `object-property-newline`, `import/no-nodejs-modules`, `import/no-namespace`, and `import/order`. ([#17](https://github.com/CodingZeal/eslint-config-zeal/pull/17))
 
 ### Changed
 
-* Disable the `react/prop-types` rule. While propTypes provide handy documentation, we felt that the maintenance cost of keeping them around was too high, so we've disabled the rule by default. ([#16](https://github.com/CodingZeal/eslint-config-zeal/pull/16))
+- Disable the `react/prop-types` rule. While propTypes provide handy documentation, we felt that the maintenance cost of keeping them around was too high, so we've disabled the rule by default. ([#16](https://github.com/CodingZeal/eslint-config-zeal/pull/16))
 
-* Update to ESLint 2.10.2, eslint-plugin-import 1.8.0, and eslint-plugin-react 5.1.1. ([#17](https://github.com/CodingZeal/eslint-config-zeal/pull/17))
+- Update to ESLint 2.10.2, eslint-plugin-import 1.8.0, and eslint-plugin-react 5.1.1. ([#17](https://github.com/CodingZeal/eslint-config-zeal/pull/17))
 
 ## [0.6.2](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.6.1...v0.6.2) - 2016-05-16
 
 ### Changed
 
-* Disable the `max-statements` rule in Mocha specs ([#15](https://github.com/CodingZeal/eslint-config-zeal/pull/15))
+- Disable the `max-statements` rule in Mocha specs ([#15](https://github.com/CodingZeal/eslint-config-zeal/pull/15))
 
 ## [0.6.1](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.6.0...v0.6.1) - 2016-03-21
 
 ### Added
 
-* Configure eslint-plugin-import to ignore image files ([#12](https://github.com/CodingZeal/eslint-config-zeal/pull/12))
+- Configure eslint-plugin-import to ignore image files ([#12](https://github.com/CodingZeal/eslint-config-zeal/pull/12))
 
 ## [0.6.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.5.1...v0.6.0) - 2016-03-18
 
 ### Added
 
-* Add support for new `template-curly-spacing`, `newline-before-return`, `no-restricted-globals`, and `react/prefer-stateless-function` rules. ([#11](https://github.com/CodingZeal/eslint-config-zeal/pull/11))
+- Add support for new `template-curly-spacing`, `newline-before-return`, `no-restricted-globals`, and `react/prefer-stateless-function` rules. ([#11](https://github.com/CodingZeal/eslint-config-zeal/pull/11))
 
 ### Changed
 
-* Update to ESLint 2.4.0, eslint-plugin-import 1.1.0, and eslint-plugin-react 4.2.3. Requires babel-eslint 6.0.0-beta.6 or later. ([#11](https://github.com/CodingZeal/eslint-config-zeal/pull/11))
+- Update to ESLint 2.4.0, eslint-plugin-import 1.1.0, and eslint-plugin-react 4.2.3. Requires babel-eslint 6.0.0-beta.6 or later. ([#11](https://github.com/CodingZeal/eslint-config-zeal/pull/11))
 
 ## [0.5.1](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.5.0...v0.5.1) - 2016-03-01
 
 ### Fixed
 
-* The configuration options for the `react/display-name` rule changed in eslint-plugin-react 4.0. `react.js` has been updated to adapt to the new options. ([#10](https://github.com/CodingZeal/eslint-config-zeal/pull/10))
+- The configuration options for the `react/display-name` rule changed in eslint-plugin-react 4.0. `react.js` has been updated to adapt to the new options. ([#10](https://github.com/CodingZeal/eslint-config-zeal/pull/10))
 
 ## [0.5.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.4.0...v0.5.0) - 2016-03-01
 
 ### Changed
 
-* Update [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) support to v4.1.0. If you need to continue to use version 3.x of that plugin, please keep using v0.4.0 instead of upgrading. ([#9](https://github.com/CodingZeal/eslint-config-zeal/pull/9))
+- Update [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) support to v4.1.0. If you need to continue to use version 3.x of that plugin, please keep using v0.4.0 instead of upgrading. ([#9](https://github.com/CodingZeal/eslint-config-zeal/pull/9))
 
 ## [0.4.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.3.1...v0.4.0) - 2016-02-19
 
 ### Added
 
-* Add [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) to check ES6 imports and exports. ([#7](https://github.com/CodingZeal/eslint-config-zeal/pull/7))
+- Add [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) to check ES6 imports and exports. ([#7](https://github.com/CodingZeal/eslint-config-zeal/pull/7))
 
 ### Changed
 
-* Disable the [newline-per-chained-call](http://eslint.org/docs/rules/newline-per-chained-call) rule. It fires too frequently, especially when using Chai expectations. Given that we have a pretty short line-length limit (80 chars), that tends to limit the length of chained calls already. ([#8](https://github.com/CodingZeal/eslint-config-zeal/pull/8))
+- Disable the [newline-per-chained-call](http://eslint.org/docs/rules/newline-per-chained-call) rule. It fires too frequently, especially when using Chai expectations. Given that we have a pretty short line-length limit (80 chars), that tends to limit the length of chained calls already. ([#8](https://github.com/CodingZeal/eslint-config-zeal/pull/8))
 
 ## [0.3.1](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.3.0...v0.3.1) - 2016-02-12
 
 ### Removed
 
-* Temporarily remove the `react/jsx-space-before-closing` rule. It hasn't been released in eslint-plugin-react yet. ([#6](https://github.com/CodingZeal/eslint-config-zeal/pull/6))
+- Temporarily remove the `react/jsx-space-before-closing` rule. It hasn't been released in eslint-plugin-react yet. ([#6](https://github.com/CodingZeal/eslint-config-zeal/pull/6))
 
 ## [0.3.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.2.0...v0.3.0) - 2016-02-12
 
@@ -459,21 +459,21 @@ This release is updated for ESLint 2.0, which has some backwards-incompatible ch
 
 ### Changed
 
-* Modify configuration to match changes in ESLint 2.0
-* Update rules to match those in ESLint 2.0
-* Update rules to match those in eslint-plugin-react 3.16.1
+- Modify configuration to match changes in ESLint 2.0
+- Update rules to match those in ESLint 2.0
+- Update rules to match those in eslint-plugin-react 3.16.1
 
 ## [0.2.0](https://github.com/CodingZeal/eslint-config-zeal/compare/v0.1.0...v0.2.0) - 2016-01-28
 
 ### Changed
 
-* Mark eslint and babel-eslint as `peerDependencies` and `devDependencies` instead of `dependencies`. ([#2](https://github.com/CodingZeal/eslint-config-zeal/pull/2))
+- Mark eslint and babel-eslint as `peerDependencies` and `devDependencies` instead of `dependencies`. ([#2](https://github.com/CodingZeal/eslint-config-zeal/pull/2))
 
 ## 0.1.0 - 2016-01-28
 
 ### Added
 
-* Shareable ESLint configuration representing Zeal's JavaScript coding standards
-* Additional configuration module for React development (requires [esling-plugin-react](https://github.com/yannickcr/eslint-plugin-react))
-* Additional configuration module for MochaJS tests
-* Additional configuration module for Chai expectations
+- Shareable ESLint configuration representing Zeal's JavaScript coding standards
+- Additional configuration module for React development (requires [esling-plugin-react](https://github.com/yannickcr/eslint-plugin-react))
+- Additional configuration module for MochaJS tests
+- Additional configuration module for Chai expectations

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ This plugin contains all of the rules available in:
 - [ESLint](http://eslint.org/): 4.19.1
 - [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 7.7.0
 - [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native): 3.2.1
-- [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 2.9.0
+- [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 2.13.0
 - [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest): 21.15.0
 
 ## License

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ That way, the `prettier` configurations will override any `zeal` configurations 
 
 This plugin contains all of the rules available in:
 
-- [ESLint](http://eslint.org/): 4.19.0
+- [ESLint](http://eslint.org/): 4.19.1
 - [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 7.7.0
 - [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native): 3.2.1
 - [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 2.9.0

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ You can override settings from the configuration(s) by adding them directly to y
 
 We have added some additional optional configurations that you can add on top of the base `zeal` config:
 
-* `zeal/react`: Adds rules for [React](https://github.com/reactjs) development. You'll need to install [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) to use this configuration.
-* `zeal/react-native`: Adds rules for [React Native](https://facebook.github.io/react-native/) development. You'll need to install [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native) to use this configuration.
-* `zeal/mocha`: Overrides rules for use with [Mocha](https://mochajs.org/). We recommend creating a separate `.eslintrc` file in the directory containing your tests and `extend`ing this config there.
-* `zeal/chai`: Overrides rules for use with [Chai](http://chaijs.com/). We recommend creating a separate `.eslintrc` file in the directory containing your tests and `extend`ing this config there.
-* `zeal/jest`: Adds and overrides rules for use with [Jest](http://facebook.github.io/jest/). You'll have to install [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest) to use this configuration. We recommend creating a separate `.estlintrc` file in the directory containing your tests and `extend`ing this config there.
+- `zeal/react`: Adds rules for [React](https://github.com/reactjs) development. You'll need to install [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) to use this configuration.
+- `zeal/react-native`: Adds rules for [React Native](https://facebook.github.io/react-native/) development. You'll need to install [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native) to use this configuration.
+- `zeal/mocha`: Overrides rules for use with [Mocha](https://mochajs.org/). We recommend creating a separate `.eslintrc` file in the directory containing your tests and `extend`ing this config there.
+- `zeal/chai`: Overrides rules for use with [Chai](http://chaijs.com/). We recommend creating a separate `.eslintrc` file in the directory containing your tests and `extend`ing this config there.
+- `zeal/jest`: Adds and overrides rules for use with [Jest](http://facebook.github.io/jest/). You'll have to install [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest) to use this configuration. We recommend creating a separate `.estlintrc` file in the directory containing your tests and `extend`ing this config there.
 
 You can extend multiple configurations using an array:
 
@@ -131,11 +131,11 @@ That way, the `prettier` configurations will override any `zeal` configurations 
 
 This plugin contains all of the rules available in:
 
-* [ESLint](http://eslint.org/): 4.19.0
-* [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 7.7.0
-* [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native): 3.2.1
-* [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 2.9.0
-* [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest): 21.15.0
+- [ESLint](http://eslint.org/): 4.19.0
+- [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 7.7.0
+- [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native): 3.2.1
+- [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 2.9.0
+- [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest): 21.15.0
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ That way, the `prettier` configurations will override any `zeal` configurations 
 This plugin contains all of the rules available in:
 
 - [ESLint](http://eslint.org/): 4.19.1
-- [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 7.7.0
+- [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 7.10.0
 - [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native): 3.2.1
 - [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 2.13.0
 - [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest): 21.15.0

--- a/index.js
+++ b/index.js
@@ -619,6 +619,12 @@ module.exports = {
     "import/no-webpack-loader-syntax": "warn",
     // Forbid a module from importing itself
     "import/no-self-import": "warn",
+    // Forbid a module from importing a module with a dependency path back to itself
+    "import/no-cycle": "warn",
+    // Ensures that there are no useless path segments
+    "import/no-useless-path-segments": "warn",
+    // Forbid importing modules from parent directories
+    "import/no-relative-parent-imports": "off",
 
     //
     // Import: Helpful Warnings
@@ -678,7 +684,7 @@ module.exports = {
     "import/no-anonymous-default-export": "off",
     // Prefer named exports to be grouped together in a single export declaration
     "import/group-exports": "off",
-    // Ensures that there are no useless path segments
-    "import/no-useless-path-segments": "warn"
+    // Enforce a leading comment with the webpackChunkName for dynamic imports
+    "import/dynamic-import-chunkname": "warn"
   }
 };

--- a/jest.js
+++ b/jest.js
@@ -25,6 +25,8 @@ module.exports = {
     "jest/no-focused-tests": "warn",
     // Disallow setup and teardown hooks
     "jest/no-hooks": "off",
+    // Disallow Jasmine globals
+    "jest/no-jasmine-globals": "warn",
     // Disallow importing jest
     "jest/no-jest-import": "warn",
     // Disallow identical titles

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "style linter"
   ],
   "devDependencies": {
-    "babel-eslint": "^8.2.2",
+    "babel-eslint": "^8.2.5",
     "eslint": "4.19.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-find-rules": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-find-rules": "^3.3.1",
     "eslint-plugin-import": "2.13.0",
     "eslint-plugin-jest": "21.17.0",
-    "eslint-plugin-react": "7.7.0",
+    "eslint-plugin-react": "7.10.0",
     "eslint-plugin-react-native": "3.2.1",
     "husky": "^0.14.3",
     "lint-staged": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-find-rules": "^3.3.1",
     "eslint-plugin-import": "2.9.0",
-    "eslint-plugin-jest": "21.15.0",
+    "eslint-plugin-jest": "21.17.0",
     "eslint-plugin-react": "7.7.0",
     "eslint-plugin-react-native": "3.2.1",
     "husky": "^0.14.3",

--- a/package.json
+++ b/package.json
@@ -3,17 +3,16 @@
   "description": "ESLint sharable configuration matching Zeal's style guide",
   "version": "1.5.0",
   "main": "index.js",
-  "files": ["*.js"],
+  "files": [
+    "*.js"
+  ],
   "scripts": {
     "format": "prettier --write '**/*.{js,json,md}'",
     "missing-rules": "run-p missing-rules:*",
     "missing-rules:core": "eslint-find-rules --unused --deprecated",
-    "missing-rules:jest":
-      "eslint-find-rules --no-core --unused --deprecated jest.js",
-    "missing-rules:react":
-      "eslint-find-rules --no-core --unused --deprecated react.js",
-    "missing-rules:react-native":
-      "eslint-find-rules --no-core --unused --deprecated react-native.js",
+    "missing-rules:jest": "eslint-find-rules --no-core --unused --deprecated jest.js",
+    "missing-rules:react": "eslint-find-rules --no-core --unused --deprecated react.js",
+    "missing-rules:react-native": "eslint-find-rules --no-core --unused --deprecated react-native.js",
     "precommit": "lint-staged",
     "test": "eslint .",
     "validate": "run-p test missing-rules"
@@ -56,7 +55,7 @@
     "husky": "^0.14.3",
     "lint-staged": "^7.0.0",
     "npm-run-all": "^4.1.2",
-    "prettier": "^1.10.2"
+    "prettier": "^1.13.7"
   },
   "peerDependencies": {
     "babel-eslint": ">=8.2.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-react-native": "3.2.1",
     "husky": "^0.14.3",
     "lint-staged": "^7.2.0",
-    "npm-run-all": "^4.1.2",
+    "npm-run-all": "^4.1.3",
     "prettier": "^1.13.7"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint": "4.19.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-find-rules": "^3.3.1",
-    "eslint-plugin-import": "2.9.0",
+    "eslint-plugin-import": "2.13.0",
     "eslint-plugin-jest": "21.17.0",
     "eslint-plugin-react": "7.7.0",
     "eslint-plugin-react-native": "3.2.1",
@@ -60,7 +60,7 @@
   "peerDependencies": {
     "babel-eslint": ">=8.2.2",
     "eslint": ">=4.19.1",
-    "eslint-plugin-import": ">=2.9.0"
+    "eslint-plugin-import": ">=2.13.0"
   },
   "lint-staged": {
     "linters": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-react": "7.7.0",
     "eslint-plugin-react-native": "3.2.1",
     "husky": "^0.14.3",
-    "lint-staged": "^7.0.0",
+    "lint-staged": "^7.2.0",
     "npm-run-all": "^4.1.2",
     "prettier": "^1.13.7"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "devDependencies": {
     "babel-eslint": "^8.2.2",
-    "eslint": "4.19.0",
+    "eslint": "4.19.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-find-rules": "^3.3.1",
     "eslint-plugin-import": "2.9.0",
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "babel-eslint": ">=8.2.2",
-    "eslint": ">=4.19.0",
+    "eslint": ">=4.19.1",
     "eslint-plugin-import": ">=2.9.0"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-eslint": "^8.2.2",
     "eslint": "4.19.0",
     "eslint-config-prettier": "^2.9.0",
-    "eslint-find-rules": "^3.2.1",
+    "eslint-find-rules": "^3.3.1",
     "eslint-plugin-import": "2.9.0",
     "eslint-plugin-jest": "21.15.0",
     "eslint-plugin-react": "7.7.0",

--- a/react.js
+++ b/react.js
@@ -78,6 +78,8 @@ module.exports = {
     "react/jsx-one-expression-per-line": "warn",
     // Enforce PascalCase for user-defined JSX components
     "react/jsx-pascal-case": "warn",
+    // Disallow multiple spaces between inline JSX props
+    "react/jsx-props-no-multi-spaces": "warn",
     // Enforce default props alphabetical sorting
     "react/jsx-sort-default-props": "off",
     // Enforce props alphabetical sorting
@@ -130,6 +132,8 @@ module.exports = {
     "react/no-unescaped-entities": "warn",
     // Prevent usage of unknown DOM property
     "react/no-unknown-property": "warn",
+    // Prevent usage of UNSAFE_ methods
+    "react/no-unsafe": "warn",
     // Prevent definitions of unused prop types
     "react/no-unused-prop-types": "warn",
     // Prevent definitions of unused state

--- a/yarn.lock
+++ b/yarn.lock
@@ -476,6 +476,16 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^6.0.4:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 date-fns@^1.27.2:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
@@ -1711,6 +1721,10 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+nice-try@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -1737,13 +1751,13 @@ npm-path@^2.0.2:
   dependencies:
     which "^1.2.10"
 
-npm-run-all@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.2.tgz#90d62d078792d20669139e718621186656cea056"
+npm-run-all@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.3.tgz#49f15b55a66bb4101664ce270cb18e7103f8f185"
   dependencies:
     ansi-styles "^3.2.0"
     chalk "^2.1.0"
-    cross-spawn "^5.1.0"
+    cross-spawn "^6.0.4"
     memorystream "^0.3.1"
     minimatch "^3.0.4"
     ps-tree "^1.1.0"
@@ -1904,7 +1918,7 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
@@ -2164,7 +2178,7 @@ semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
 
-"semver@2 || 3 || 4 || 5":
+"semver@2 || 3 || 4 || 5", semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.0.0-beta.40", "@babel/code-frame@^7.0.0-beta.35", "@babel/code-frame@^7.0.0-beta.40":
+"@babel/code-frame@7.0.0-beta.40", "@babel/code-frame@^7.0.0-beta.40":
   version "7.0.0-beta.40"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz#37e2b0cf7c56026b4b21d3927cadf81adec32ac6"
   dependencies:
@@ -71,15 +71,11 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-abab@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
-
-acorn-globals@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.1.0.tgz#ab716025dbe17c54d3ef81d32ece2b2d99fe2538"
+"@samverschueren/stream-to-observable@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
   dependencies:
-    acorn "^5.0.0"
+    any-observable "^0.3.0"
 
 acorn-jsx@^3.0.0:
   version "3.0.1"
@@ -91,10 +87,6 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^5.0.0, acorn@^5.3.0:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
-
 acorn@^5.5.0:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
@@ -103,7 +95,7 @@ ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
-ajv@^5.1.0, ajv@^5.2.3:
+ajv@^5.2.3:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -147,9 +139,9 @@ ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   dependencies:
     color-convert "^1.9.0"
 
-any-observable@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.2.0.tgz#c67870058003579009083f54ac0abafb5c33d242"
+any-observable@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
 
 app-root-path@^2.0.1:
   version "2.0.1"
@@ -161,27 +153,17 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-arr-diff@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
-  dependencies:
-    arr-flatten "^1.0.1"
-
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
 
-arr-flatten@^1.0.1, arr-flatten@^1.1.0:
+arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
 
 arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
-
-array-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
 array-filter@~0.0.0:
   version "0.0.1"
@@ -212,10 +194,6 @@ array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
 
-array-unique@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
-
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
@@ -228,37 +206,13 @@ asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
-asn1@~0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
-
-assert-plus@1.0.0, assert-plus@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
-
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
-async-limiter@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
-
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-
 atob@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
-
-aws-sign2@~0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
-
-aws4@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
 babel-code-frame@^6.22.0:
   version "6.22.0"
@@ -299,38 +253,12 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-bcrypt-pbkdf@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
-  dependencies:
-    tweetnacl "^0.14.3"
-
-boom@4.x.x:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
-  dependencies:
-    hoek "4.x.x"
-
-boom@5.x.x:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
-  dependencies:
-    hoek "4.x.x"
-
 brace-expansion@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
   dependencies:
     balanced-match "^0.4.1"
     concat-map "0.0.1"
-
-braces@^1.8.2:
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
-  dependencies:
-    expand-range "^1.8.1"
-    preserve "^0.2.0"
-    repeat-element "^1.1.2"
 
 braces@^2.3.1:
   version "2.3.1"
@@ -348,16 +276,6 @@ braces@^2.3.1:
     snapdragon-node "^2.0.1"
     split-string "^3.0.2"
     to-regex "^3.0.1"
-
-browser-process-hrtime@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
-
-browser-resolve@^1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
-  dependencies:
-    resolve "1.1.7"
 
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
@@ -387,17 +305,9 @@ callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
-callsites@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
-
 camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
-
-caseless@~0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
 chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -510,12 +420,6 @@ color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
-combined-stream@1.0.6, combined-stream@~1.0.5:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
-  dependencies:
-    delayed-stream "~1.0.0"
-
 commander@^2.14.1:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
@@ -544,10 +448,6 @@ contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
-content-type-parser@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.2.tgz#caabe80623e63638b2502fd4c7f12ff4ce2352e7"
-
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
@@ -556,18 +456,17 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-util-is@1.0.2, core-util-is@~1.0.0:
+core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cosmiconfig@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
+cosmiconfig@^5.0.2:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.5.tgz#a809e3c2306891ce17ab70359dc8bdf661fe2cd0"
   dependencies:
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
-    require-from-string "^2.0.1"
 
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
@@ -576,28 +475,6 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-cryptiles@3.x.x:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
-  dependencies:
-    boom "5.x.x"
-
-cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
-
-"cssstyle@>= 0.2.37 < 0.3.0":
-  version "0.2.37"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
-  dependencies:
-    cssom "0.3.x"
-
-dashdash@^1.12.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
-  dependencies:
-    assert-plus "^1.0.0"
 
 date-fns@^1.27.2:
   version "1.29.0"
@@ -675,14 +552,6 @@ del@^2.0.2:
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
 
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-
-diff@^3.2.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
-
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -702,21 +571,9 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
-domexception@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
-  dependencies:
-    webidl-conversions "^4.0.2"
-
 duplexer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
-
-ecc-jsbn@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
-  dependencies:
-    jsbn "~0.1.0"
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -764,17 +621,6 @@ es-to-primitive@^1.1.1:
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-
-escodegen@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.0.tgz#9811a2f265dc1cd3894420ee3717064b632b8852"
-  dependencies:
-    esprima "^3.1.3"
-    estraverse "^4.2.0"
-    esutils "^2.0.2"
-    optionator "^0.8.1"
-  optionalDependencies:
-    source-map "~0.5.6"
 
 eslint-config-prettier@^2.9.0:
   version "2.9.0"
@@ -910,10 +756,6 @@ espree@^3.5.4:
     acorn "^5.5.0"
     acorn-jsx "^3.0.0"
 
-esprima@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
-
 esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
@@ -931,7 +773,7 @@ esrecurse@^4.1.0:
     estraverse "~4.1.0"
     object-assign "^4.0.1"
 
-estraverse@^4.0.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -983,12 +825,6 @@ exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
-expand-brackets@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
-  dependencies:
-    is-posix-bracket "^0.1.0"
-
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
@@ -1000,23 +836,6 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-expand-range@^1.8.1:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
-  dependencies:
-    fill-range "^2.1.0"
-
-expect@^22.4.0:
-  version "22.4.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-22.4.0.tgz#371edf1ae15b83b5bf5ec34b42f1584660a36c16"
-  dependencies:
-    ansi-styles "^3.2.0"
-    jest-diff "^22.4.0"
-    jest-get-type "^22.1.0"
-    jest-matcher-utils "^22.4.0"
-    jest-message-util "^22.4.0"
-    jest-regex-util "^22.1.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -1031,10 +850,6 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
-
 external-editor@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.4.tgz#1ed9199da9cbfe2ef2f7a31b2fde8b0d12368972"
@@ -1042,12 +857,6 @@ external-editor@^2.0.4:
     iconv-lite "^0.4.17"
     jschardet "^1.4.2"
     tmp "^0.0.31"
-
-extglob@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
-  dependencies:
-    is-extglob "^1.0.0"
 
 extglob@^2.0.4:
   version "2.0.4"
@@ -1061,14 +870,6 @@ extglob@^2.0.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-extsprintf@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-
-extsprintf@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
 fast-deep-equal@^1.0.0:
   version "1.0.0"
@@ -1114,20 +915,6 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-filename-regex@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
-
-fill-range@^2.1.0:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
-  dependencies:
-    is-number "^2.1.0"
-    isobject "^2.0.0"
-    randomatic "^1.1.3"
-    repeat-element "^1.1.2"
-    repeat-string "^1.5.2"
-
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
@@ -1163,31 +950,13 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-for-in@^1.0.1, for-in@^1.0.2:
+for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
-
-for-own@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
-  dependencies:
-    for-in "^1.0.1"
 
 foreach@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
-
-forever-agent@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
-
-form-data@~2.3.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "1.0.6"
-    mime-types "^2.1.12"
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -1235,26 +1004,7 @@ get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
 
-getpass@^0.1.1:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
-  dependencies:
-    assert-plus "^1.0.0"
-
-glob-base@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
-  dependencies:
-    glob-parent "^2.0.0"
-    is-glob "^2.0.0"
-
-glob-parent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
-  dependencies:
-    is-glob "^2.0.0"
-
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -1284,20 +1034,9 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-
-har-schema@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-
-har-validator@~5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
-  dependencies:
-    ajv "^5.1.0"
-    har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -1346,36 +1085,9 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
-hawk@~6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
-  dependencies:
-    boom "4.x.x"
-    cryptiles "3.x.x"
-    hoek "4.x.x"
-    sntp "2.x.x"
-
-hoek@4.x.x:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
-
 hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
-
-html-encoding-sniffer@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
-  dependencies:
-    whatwg-encoding "^1.0.1"
-
-http-signature@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  dependencies:
-    assert-plus "^1.0.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
 
 husky@^0.14.3:
   version "0.14.3"
@@ -1385,13 +1097,13 @@ husky@^0.14.3:
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
-iconv-lite@0.4.19, iconv-lite@~0.4.13:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
-
 iconv-lite@^0.4.17:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
+
+iconv-lite@~0.4.13:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
 ignore@^3.3.3:
   version "3.3.3"
@@ -1523,16 +1235,6 @@ is-directory@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
-is-dotfile@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
-
-is-equal-shallow@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
-  dependencies:
-    is-primitive "^2.0.0"
-
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -1542,10 +1244,6 @@ is-extendable@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
   dependencies:
     is-plain-object "^2.0.4"
-
-is-extglob@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -1567,27 +1265,11 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
-is-generator-fn@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-1.0.0.tgz#969d49e1bb3329f6bb7f09089be26578b2ddd46a"
-
-is-glob@^2.0.0, is-glob@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
-  dependencies:
-    is-extglob "^1.0.0"
-
 is-glob@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
   dependencies:
     is-extglob "^2.1.1"
-
-is-number@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
-  dependencies:
-    kind-of "^3.0.2"
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -1603,11 +1285,11 @@ is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
-is-observable@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-0.2.0.tgz#b361311d83c6e5d726cabf5e250b0237106f5ae2"
+is-observable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
   dependencies:
-    symbol-observable "^0.2.2"
+    symbol-observable "^1.1.0"
 
 is-odd@^2.0.0:
   version "2.0.0"
@@ -1637,14 +1319,6 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-posix-bracket@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
-
-is-primitive@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
-
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
@@ -1672,10 +1346,6 @@ is-stream@^1.0.1, is-stream@^1.1.0:
 is-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
-
-is-typedarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -1706,135 +1376,18 @@ isomorphic-fetch@^2.1.1:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
 
-isstream@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
-
-jest-config@^22.4.2:
-  version "22.4.2"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-22.4.2.tgz#580ba5819bf81a5e48f4fd470e8b81834f45c855"
-  dependencies:
-    chalk "^2.0.1"
-    glob "^7.1.1"
-    jest-environment-jsdom "^22.4.1"
-    jest-environment-node "^22.4.1"
-    jest-get-type "^22.1.0"
-    jest-jasmine2 "^22.4.2"
-    jest-regex-util "^22.1.0"
-    jest-resolve "^22.4.2"
-    jest-util "^22.4.1"
-    jest-validate "^22.4.2"
-    pretty-format "^22.4.0"
-
-jest-diff@^22.4.0:
-  version "22.4.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-22.4.0.tgz#384c2b78519ca44ca126382df53f134289232525"
-  dependencies:
-    chalk "^2.0.1"
-    diff "^3.2.0"
-    jest-get-type "^22.1.0"
-    pretty-format "^22.4.0"
-
-jest-environment-jsdom@^22.4.1:
-  version "22.4.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-22.4.1.tgz#754f408872441740100d3917e5ec40c74de6447f"
-  dependencies:
-    jest-mock "^22.2.0"
-    jest-util "^22.4.1"
-    jsdom "^11.5.1"
-
-jest-environment-node@^22.4.1:
-  version "22.4.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-22.4.1.tgz#418850eb654596b8d6e36c2021cbedbc23df8e16"
-  dependencies:
-    jest-mock "^22.2.0"
-    jest-util "^22.4.1"
-
 jest-get-type@^22.1.0:
   version "22.1.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.1.0.tgz#4e90af298ed6181edc85d2da500dbd2753e0d5a9"
 
-jest-jasmine2@^22.4.2:
-  version "22.4.2"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-22.4.2.tgz#dfd3d259579ed6f52510d8f1ab692808f0d40691"
+jest-validate@^23.0.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.2.0.tgz#67c8b909e11af1701765238894c67ac3291b195e"
   dependencies:
     chalk "^2.0.1"
-    co "^4.6.0"
-    expect "^22.4.0"
-    graceful-fs "^4.1.11"
-    is-generator-fn "^1.0.0"
-    jest-diff "^22.4.0"
-    jest-matcher-utils "^22.4.0"
-    jest-message-util "^22.4.0"
-    jest-snapshot "^22.4.0"
-    jest-util "^22.4.1"
-    source-map-support "^0.5.0"
-
-jest-matcher-utils@^22.4.0:
-  version "22.4.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.4.0.tgz#d55f5faf2270462736bdf7c7485ee931c9d4b6a1"
-  dependencies:
-    chalk "^2.0.1"
-    jest-get-type "^22.1.0"
-    pretty-format "^22.4.0"
-
-jest-message-util@^22.4.0:
-  version "22.4.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-22.4.0.tgz#e3d861df16d2fee60cb2bc8feac2188a42579642"
-  dependencies:
-    "@babel/code-frame" "^7.0.0-beta.35"
-    chalk "^2.0.1"
-    micromatch "^2.3.11"
-    slash "^1.0.0"
-    stack-utils "^1.0.1"
-
-jest-mock@^22.2.0:
-  version "22.2.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-22.2.0.tgz#444b3f9488a7473adae09bc8a77294afded397a7"
-
-jest-regex-util@^22.1.0:
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-22.1.0.tgz#5daf2fe270074b6da63e5d85f1c9acc866768f53"
-
-jest-resolve@^22.4.2:
-  version "22.4.2"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-22.4.2.tgz#25d88aa4147462c9c1c6a1ba16250d3794c24d00"
-  dependencies:
-    browser-resolve "^1.11.2"
-    chalk "^2.0.1"
-
-jest-snapshot@^22.4.0:
-  version "22.4.0"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-22.4.0.tgz#03d3ce63f8fa7352388afc6a3c8b5ccc3a180ed7"
-  dependencies:
-    chalk "^2.0.1"
-    jest-diff "^22.4.0"
-    jest-matcher-utils "^22.4.0"
-    mkdirp "^0.5.1"
-    natural-compare "^1.4.0"
-    pretty-format "^22.4.0"
-
-jest-util@^22.4.1:
-  version "22.4.1"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-22.4.1.tgz#dd17c3bdb067f8e90591563ec0c42bf847dc249f"
-  dependencies:
-    callsites "^2.0.0"
-    chalk "^2.0.1"
-    graceful-fs "^4.1.11"
-    is-ci "^1.0.10"
-    jest-message-util "^22.4.0"
-    mkdirp "^0.5.1"
-    source-map "^0.6.0"
-
-jest-validate@^22.4.0, jest-validate@^22.4.2:
-  version "22.4.2"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-22.4.2.tgz#e789a4e056173bf97fe797a2df2d52105c57d4f4"
-  dependencies:
-    chalk "^2.0.1"
-    jest-config "^22.4.2"
     jest-get-type "^22.1.0"
     leven "^2.1.0"
-    pretty-format "^22.4.0"
+    pretty-format "^23.2.0"
 
 js-tokens@^3.0.0:
   version "3.0.1"
@@ -1847,44 +1400,9 @@ js-yaml@^3.9.0, js-yaml@^3.9.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-jsbn@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
-
 jschardet@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.4.2.tgz#2aa107f142af4121d145659d44f50830961e699a"
-
-jsdom@^11.5.1:
-  version "11.6.2"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.6.2.tgz#25d1ef332d48adf77fc5221fe2619967923f16bb"
-  dependencies:
-    abab "^1.0.4"
-    acorn "^5.3.0"
-    acorn-globals "^4.1.0"
-    array-equal "^1.0.0"
-    browser-process-hrtime "^0.1.2"
-    content-type-parser "^1.0.2"
-    cssom ">= 0.3.2 < 0.4.0"
-    cssstyle ">= 0.2.37 < 0.3.0"
-    domexception "^1.0.0"
-    escodegen "^1.9.0"
-    html-encoding-sniffer "^1.0.2"
-    left-pad "^1.2.0"
-    nwmatcher "^1.4.3"
-    parse5 "4.0.0"
-    pn "^1.1.0"
-    request "^2.83.0"
-    request-promise-native "^1.0.5"
-    sax "^1.2.4"
-    symbol-tree "^3.2.2"
-    tough-cookie "^2.3.3"
-    w3c-hr-time "^1.0.1"
-    webidl-conversions "^4.0.2"
-    whatwg-encoding "^1.0.3"
-    whatwg-url "^6.4.0"
-    ws "^4.0.0"
-    xml-name-validator "^3.0.0"
 
 jsesc@^2.5.1:
   version "2.5.1"
@@ -1898,30 +1416,13 @@ json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
-json-stringify-safe@~5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-
-jsprim@^1.2.2:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
-  dependencies:
-    assert-plus "1.0.0"
-    extsprintf "1.3.0"
-    json-schema "0.2.3"
-    verror "1.10.0"
 
 jsx-ast-utils@^2.0.1:
   version "2.0.1"
@@ -1961,10 +1462,6 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-left-pad@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.2.0.tgz#d30a73c6b8201d8f7d8e7956ba9616087a68e0ee"
-
 leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
@@ -1976,21 +1473,22 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lint-staged@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-7.0.0.tgz#57926c63201e7bd38ca0576d74391efa699b4a9d"
+lint-staged@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-7.2.0.tgz#bdf4bb7f2f37fe689acfaec9999db288a5b26888"
   dependencies:
     app-root-path "^2.0.1"
     chalk "^2.3.1"
     commander "^2.14.1"
-    cosmiconfig "^4.0.0"
+    cosmiconfig "^5.0.2"
     debug "^3.1.0"
     dedent "^0.7.0"
     execa "^0.9.0"
     find-parent-dir "^0.3.0"
     is-glob "^4.0.0"
-    jest-validate "^22.4.0"
-    listr "^0.13.0"
+    is-windows "^1.0.2"
+    jest-validate "^23.0.0"
+    listr "^0.14.1"
     lodash "^4.17.5"
     log-symbols "^2.2.0"
     micromatch "^3.1.8"
@@ -1998,8 +1496,9 @@ lint-staged@^7.0.0:
     p-map "^1.1.1"
     path-is-inside "^1.0.2"
     pify "^3.0.0"
-    please-upgrade-node "^3.0.1"
-    staged-git-files "1.1.0"
+    please-upgrade-node "^3.0.2"
+    staged-git-files "1.1.1"
+    string-argv "^0.0.2"
     stringify-object "^3.2.2"
 
 listr-silent-renderer@^1.1.1:
@@ -2028,15 +1527,15 @@ listr-verbose-renderer@^0.4.0:
     date-fns "^1.27.2"
     figures "^1.7.0"
 
-listr@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/listr/-/listr-0.13.0.tgz#20bb0ba30bae660ee84cc0503df4be3d5623887d"
+listr@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.1.tgz#8a7afa4a7135cee4c921d128e0b7dfc6e522d43d"
   dependencies:
-    chalk "^1.1.3"
+    "@samverschueren/stream-to-observable" "^0.3.0"
     cli-truncate "^0.2.1"
     figures "^1.7.0"
     indent-string "^2.1.0"
-    is-observable "^0.2.0"
+    is-observable "^1.1.0"
     is-promise "^2.1.0"
     is-stream "^1.1.0"
     listr-silent-renderer "^1.1.1"
@@ -2046,8 +1545,7 @@ listr@^0.13.0:
     log-update "^1.0.2"
     ora "^0.2.3"
     p-map "^1.1.1"
-    rxjs "^5.4.2"
-    stream-to-observable "^0.2.0"
+    rxjs "^6.1.0"
     strip-ansi "^3.0.1"
 
 load-json-file@^2.0.0:
@@ -2075,17 +1573,13 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash.sortby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
-
-lodash@^4.13.1, lodash@^4.17.5:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
-
 lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@^4.17.5:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -2143,24 +1637,6 @@ memorystream@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
 
-micromatch@^2.3.11:
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
-  dependencies:
-    arr-diff "^2.0.0"
-    array-unique "^0.2.1"
-    braces "^1.8.2"
-    expand-brackets "^0.1.4"
-    extglob "^0.3.1"
-    filename-regex "^2.0.0"
-    is-extglob "^1.0.0"
-    is-glob "^2.0.1"
-    kind-of "^3.0.2"
-    normalize-path "^2.0.1"
-    object.omit "^2.0.0"
-    parse-glob "^3.0.4"
-    regex-cache "^0.4.2"
-
 micromatch@^3.1.8:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.8.tgz#5c8caa008de588eebb395e8c0ad12c128f25fff1"
@@ -2178,16 +1654,6 @@ micromatch@^3.1.8:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-mime-db@~1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
-
-mime-types@^2.1.12, mime-types@~2.1.17:
-  version "2.1.18"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
-  dependencies:
-    mime-db "~1.33.0"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -2265,12 +1731,6 @@ normalize-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
-normalize-path@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
-  dependencies:
-    remove-trailing-separator "^1.0.1"
-
 npm-path@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.3.tgz#15cff4e1c89a38da77f56f6055b24f975dfb2bbe"
@@ -2309,14 +1769,6 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nwmatcher@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.3.tgz#64348e3b3d80f035b40ac11563d278f8b72db89c"
-
-oauth-sign@~0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
-
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -2338,13 +1790,6 @@ object-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   dependencies:
     isobject "^3.0.0"
-
-object.omit@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
-  dependencies:
-    for-own "^0.1.4"
-    is-extendable "^0.1.1"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -2368,7 +1813,7 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-optionator@^0.8.1, optionator@^0.8.2:
+optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -2424,15 +1869,6 @@ p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
 
-parse-glob@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
-  dependencies:
-    glob-base "^0.3.0"
-    is-dotfile "^1.0.0"
-    is-extglob "^1.0.0"
-    is-glob "^2.0.0"
-
 parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
@@ -2445,10 +1881,6 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
-
-parse5@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -2498,10 +1930,6 @@ pause-stream@0.0.11:
   dependencies:
     through "~2.3"
 
-performance-now@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -2526,17 +1954,15 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
-please-upgrade-node@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.0.1.tgz#0a681f2c18915e5433a5ca2cd94e0b8206a782db"
+please-upgrade-node@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.0.2.tgz#7b9eaeca35aa4a43d6ebdfd10616c042f9a83acc"
+  dependencies:
+    semver-compare "^1.0.0"
 
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
-
-pn@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -2546,17 +1972,13 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
-preserve@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
-
 prettier@^1.13.7:
   version "1.13.7"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
 
-pretty-format@^22.4.0:
-  version "22.4.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.0.tgz#237b1f7e1c50ed03bc65c03ccc29d7c8bb7beb94"
+pretty-format@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.2.0.tgz#3b0aaa63c018a53583373c1cb3a5d96cc5e83017"
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -2593,25 +2015,6 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
-punycode@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-
-punycode@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
-
-qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
-
-randomatic@^1.1.3:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
-  dependencies:
-    is-number "^3.0.0"
-    kind-of "^4.0.0"
-
 read-pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
@@ -2647,12 +2050,6 @@ readable-stream@^2.2.2:
     string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
 
-regex-cache@^0.4.2:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
-  dependencies:
-    is-equal-shallow "^0.1.3"
-
 regex-not@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
@@ -2664,15 +2061,11 @@ regexpp@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.0.1.tgz#d857c3a741dce075c2848dcb019a0a975b190d43"
 
-remove-trailing-separator@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
-
 repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.2, repeat-string@^1.6.1:
+repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -2682,54 +2075,9 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request-promise-core@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
-  dependencies:
-    lodash "^4.13.1"
-
-request-promise-native@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
-  dependencies:
-    request-promise-core "1.1.1"
-    stealthy-require "^1.1.0"
-    tough-cookie ">=2.3.3"
-
-request@^2.83.0:
-  version "2.83.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.6.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.1"
-    forever-agent "~0.6.1"
-    form-data "~2.3.1"
-    har-validator "~5.0.3"
-    hawk "~6.0.2"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.17"
-    oauth-sign "~0.8.2"
-    performance-now "^2.1.0"
-    qs "~6.5.1"
-    safe-buffer "^5.1.1"
-    stringstream "~0.0.5"
-    tough-cookie "~2.3.3"
-    tunnel-agent "^0.6.0"
-    uuid "^3.1.0"
-
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-
-require-from-string@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.1.tgz#c545233e9d7da6616e9d59adfb39fc9f588676ff"
 
 require-main-filename@^1.0.1:
   version "1.0.1"
@@ -2749,10 +2097,6 @@ resolve-from@^1.0.0:
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
-
-resolve@1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
 resolve@^1.2.0:
   version "1.3.3"
@@ -2800,15 +2144,11 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-rxjs@^5.4.2:
-  version "5.5.6"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
+rxjs@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.2.1.tgz#246cebec189a6cbc143a3ef9f62d6f4c91813ca1"
   dependencies:
-    symbol-observable "1.0.1"
-
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+    tslib "^1.9.0"
 
 safe-buffer@~5.0.1:
   version "5.0.1"
@@ -2820,9 +2160,9 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-sax@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
 
 "semver@2 || 3 || 4 || 5":
   version "5.5.0"
@@ -2887,10 +2227,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-slash@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
-
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
@@ -2928,12 +2264,6 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^2.0.0"
 
-sntp@2.x.x:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
-  dependencies:
-    hoek "4.x.x"
-
 source-map-resolve@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
@@ -2944,23 +2274,13 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.0:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.3.tgz#2b3d5fff298cfa4d1afd7d4352d569e9a0158e76"
-  dependencies:
-    source-map "^0.6.0"
-
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
-source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.6:
+source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-
-source-map@^0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -2992,27 +2312,9 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-sshpk@^1.7.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"
-  dependencies:
-    asn1 "~0.2.3"
-    assert-plus "^1.0.0"
-    dashdash "^1.12.0"
-    getpass "^0.1.1"
-  optionalDependencies:
-    bcrypt-pbkdf "^1.0.0"
-    ecc-jsbn "~0.1.1"
-    jsbn "~0.1.0"
-    tweetnacl "~0.14.0"
-
-stack-utils@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
-
-staged-git-files@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-1.1.0.tgz#1a9bb131c1885601023c7aaddd3d54c22142c526"
+staged-git-files@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-1.1.1.tgz#37c2218ef0d6d26178b1310719309a16a59f8f7b"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -3021,21 +2323,15 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stealthy-require@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
-
 stream-combiner@~0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
   dependencies:
     duplexer "~0.1.1"
 
-stream-to-observable@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.2.0.tgz#59d6ea393d87c2c0ddac10aa0d561bc6ba6f0e10"
-  dependencies:
-    any-observable "^0.2.0"
+string-argv@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -3073,10 +2369,6 @@ stringify-object@^3.2.2:
     get-own-enumerable-property-symbols "^2.0.1"
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
-
-stringstream@~0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -3122,17 +2414,9 @@ supports-color@^5.2.0:
   dependencies:
     has-flag "^3.0.0"
 
-symbol-observable@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
-
-symbol-observable@^0.2.2:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
-
-symbol-tree@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
+symbol-observable@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
 table@4.0.2:
   version "4.0.2"
@@ -3184,18 +2468,6 @@ to-regex@^3.0.1:
     extend-shallow "^2.0.1"
     regex-not "^1.0.0"
 
-tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
-  dependencies:
-    punycode "^1.4.1"
-
-tr46@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
-  dependencies:
-    punycode "^2.1.0"
-
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
@@ -3204,15 +2476,9 @@ tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
 
-tunnel-agent@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
-  dependencies:
-    safe-buffer "^5.0.1"
-
-tweetnacl@^0.14.3, tweetnacl@~0.14.0:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -3260,10 +2526,6 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-uuid@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
-
 validate-npm-package-license@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
@@ -3271,41 +2533,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-verror@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
-  dependencies:
-    assert-plus "^1.0.0"
-    core-util-is "1.0.2"
-    extsprintf "^1.2.0"
-
-w3c-hr-time@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
-  dependencies:
-    browser-process-hrtime "^0.1.2"
-
-webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
-
-whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz#57c235bc8657e914d24e1a397d3c82daee0a6ba3"
-  dependencies:
-    iconv-lite "0.4.19"
-
 whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
-
-whatwg-url@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.0.tgz#08fdf2b9e872783a7a1f6216260a1d66cc722e08"
-  dependencies:
-    lodash.sortby "^4.7.0"
-    tr46 "^1.0.0"
-    webidl-conversions "^4.0.1"
 
 which-module@^2.0.0:
   version "2.0.0"
@@ -3341,17 +2571,6 @@ write@^0.2.1:
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
-
-ws@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-4.1.0.tgz#a979b5d7d4da68bf54efe0408967c324869a7289"
-  dependencies:
-    async-limiter "~1.0.0"
-    safe-buffer "~5.1.0"
-
-xml-name-validator@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
 y18n@^3.2.1:
   version "3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -638,9 +638,9 @@ eslint-config-prettier@^2.9.0:
   dependencies:
     get-stdin "^5.0.1"
 
-eslint-find-rules@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-find-rules/-/eslint-find-rules-3.2.1.tgz#39405ca41891d15ba9c4c023366566c3de9395ea"
+eslint-find-rules@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-find-rules/-/eslint-find-rules-3.3.1.tgz#46a86c2fc9e9be2b33235234e1820e1f045793a9"
   dependencies:
     cliui "^3.2.0"
     eslint-rule-documentation "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -277,7 +277,7 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-builtin-modules@^1.0.0, builtin-modules@^1.1.1:
+builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -656,27 +656,27 @@ eslint-import-resolver-node@^0.3.1:
     debug "^2.6.8"
     resolve "^1.2.0"
 
-eslint-module-utils@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz#abaec824177613b8a95b299639e1b6facf473449"
+eslint-module-utils@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz#b270362cd88b1a48ad308976ce7fa54e98411746"
   dependencies:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
-eslint-plugin-import@2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz#26002efbfca5989b7288ac047508bd24f217b169"
+eslint-plugin-import@2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.13.0.tgz#df24f241175e312d91662dc91ca84064caec14ed"
   dependencies:
-    builtin-modules "^1.1.1"
     contains-path "^0.1.0"
     debug "^2.6.8"
     doctrine "1.5.0"
     eslint-import-resolver-node "^0.3.1"
-    eslint-module-utils "^2.1.1"
+    eslint-module-utils "^2.2.0"
     has "^1.0.1"
     lodash "^4.17.4"
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
+    resolve "^1.6.0"
 
 eslint-plugin-jest@21.17.0:
   version "21.17.0"
@@ -2115,6 +2115,12 @@ resolve-url@^0.2.1:
 resolve@^1.2.0:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
+  dependencies:
+    path-parse "^1.0.5"
+
+resolve@^1.6.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
     path-parse "^1.0.5"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,10 +202,6 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asap@~2.0.3:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -452,10 +448,6 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -569,12 +561,6 @@ doctrine@1.5.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.2.tgz#68f96ce8efc56cc42651f1faadb4f175273b0075"
-  dependencies:
-    esutils "^2.0.2"
-
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
@@ -588,12 +574,6 @@ duplexer@~0.1.1:
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
-
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  dependencies:
-    iconv-lite "~0.4.13"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
@@ -692,14 +672,14 @@ eslint-plugin-react-native@3.2.1:
   dependencies:
     eslint-plugin-react-native-globals "^0.1.1"
 
-eslint-plugin-react@7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz#f606c719dbd8a1a2b3d25c16299813878cca0160"
+eslint-plugin-react@7.10.0:
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.10.0.tgz#af5c1fef31c4704db02098f9be18202993828b50"
   dependencies:
-    doctrine "^2.0.2"
-    has "^1.0.1"
+    doctrine "^2.1.0"
+    has "^1.0.3"
     jsx-ast-utils "^2.0.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
 
 eslint-rule-documentation@^1.0.0:
   version "1.0.20"
@@ -893,18 +873,6 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fbjs@^0.8.16:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
-
 figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -1095,6 +1063,12 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  dependencies:
+    function-bind "^1.1.1"
+
 hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
@@ -1110,10 +1084,6 @@ husky@^0.14.3:
 iconv-lite@^0.4.17:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
-
-iconv-lite@~0.4.13:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
 ignore@^3.3.3:
   version "3.3.3"
@@ -1349,7 +1319,7 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -1378,13 +1348,6 @@ isobject@^2.0.0:
 isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 jest-get-type@^22.1.0:
   version "22.1.0"
@@ -1725,13 +1688,6 @@ nice-try@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
 
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
-
 normalize-package-data@^2.3.2:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
@@ -2005,17 +1961,10 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
-    asap "~2.0.3"
-
-prop-types@^15.6.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
-  dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
@@ -2219,10 +2168,6 @@ set-value@^2.0.0:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
-
-setimmediate@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -2510,10 +2455,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-ua-parser-js@^0.7.9:
-  version "0.7.17"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
-
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -2552,10 +2493,6 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
-
-whatwg-fetch@>=0.10.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 which-module@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2550,9 +2550,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
+prettier@^1.13.7:
+  version "1.13.7"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
 
 pretty-format@^22.4.0:
   version "22.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,70 +2,77 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.0.0-beta.40", "@babel/code-frame@^7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz#37e2b0cf7c56026b4b21d3927cadf81adec32ac6"
+"@babel/code-frame@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz#2a02643368de80916162be70865c97774f3adbd9"
   dependencies:
-    "@babel/highlight" "7.0.0-beta.40"
+    "@babel/highlight" "7.0.0-beta.44"
 
-"@babel/generator@7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.40.tgz#ab61f9556f4f71dbd1138949c795bb9a21e302ea"
+"@babel/generator@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.44.tgz#c7e67b9b5284afcf69b309b50d7d37f3e5033d42"
   dependencies:
-    "@babel/types" "7.0.0-beta.40"
+    "@babel/types" "7.0.0-beta.44"
     jsesc "^2.5.1"
     lodash "^4.2.0"
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-"@babel/helper-function-name@7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.40.tgz#9d033341ab16517f40d43a73f2d81fc431ccd7b6"
+"@babel/helper-function-name@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz#e18552aaae2231100a6e485e03854bc3532d44dd"
   dependencies:
-    "@babel/helper-get-function-arity" "7.0.0-beta.40"
-    "@babel/template" "7.0.0-beta.40"
-    "@babel/types" "7.0.0-beta.40"
+    "@babel/helper-get-function-arity" "7.0.0-beta.44"
+    "@babel/template" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helper-get-function-arity@7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.40.tgz#ac0419cf067b0ec16453e1274f03878195791c6e"
+"@babel/helper-get-function-arity@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz#d03ca6dd2b9f7b0b1e6b32c56c72836140db3a15"
   dependencies:
-    "@babel/types" "7.0.0-beta.40"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/highlight@7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.40.tgz#b43d67d76bf46e1d10d227f68cddcd263786b255"
+"@babel/helper-split-export-declaration@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz#c0b351735e0fbcb3822c8ad8db4e583b05ebd9dc"
+  dependencies:
+    "@babel/types" "7.0.0-beta.44"
+
+"@babel/highlight@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.44.tgz#18c94ce543916a80553edcdcf681890b200747d5"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/template@7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.40.tgz#034988c6424eb5c3268fe6a608626de1f4410fc8"
+"@babel/template@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.40"
-    "@babel/types" "7.0.0-beta.40"
-    babylon "7.0.0-beta.40"
+    "@babel/code-frame" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
+    babylon "7.0.0-beta.44"
     lodash "^4.2.0"
 
-"@babel/traverse@^7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.40.tgz#d140e449b2e093ef9fe1a2eecc28421ffb4e521e"
+"@babel/traverse@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.44.tgz#a970a2c45477ad18017e2e465a0606feee0d2966"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.40"
-    "@babel/generator" "7.0.0-beta.40"
-    "@babel/helper-function-name" "7.0.0-beta.40"
-    "@babel/types" "7.0.0-beta.40"
-    babylon "7.0.0-beta.40"
-    debug "^3.0.1"
+    "@babel/code-frame" "7.0.0-beta.44"
+    "@babel/generator" "7.0.0-beta.44"
+    "@babel/helper-function-name" "7.0.0-beta.44"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
+    babylon "7.0.0-beta.44"
+    debug "^3.1.0"
     globals "^11.1.0"
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-"@babel/types@7.0.0-beta.40", "@babel/types@^7.0.0-beta.40":
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.40.tgz#25c3d7aae14126abe05fcb098c65a66b6d6b8c14"
+"@babel/types@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.44.tgz#6b1b164591f77dec0a0342aca995f2d046b3a757"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.2.0"
@@ -218,20 +225,20 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-eslint@^8.2.2:
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.2.2.tgz#1102273354c6f0b29b4ea28a65f97d122296b68b"
+babel-eslint@^8.2.5:
+  version "8.2.5"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.2.5.tgz#dc2331c259d36782aa189da510c43dedd5adc7a3"
   dependencies:
-    "@babel/code-frame" "^7.0.0-beta.40"
-    "@babel/traverse" "^7.0.0-beta.40"
-    "@babel/types" "^7.0.0-beta.40"
-    babylon "^7.0.0-beta.40"
+    "@babel/code-frame" "7.0.0-beta.44"
+    "@babel/traverse" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
+    babylon "7.0.0-beta.44"
     eslint-scope "~3.7.1"
     eslint-visitor-keys "^1.0.0"
 
-babylon@7.0.0-beta.40, babylon@^7.0.0-beta.40:
-  version "7.0.0-beta.40"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.40.tgz#91fc8cd56d5eb98b28e6fde41045f2957779940a"
+babylon@7.0.0-beta.44:
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.44.tgz#89159e15e6e30c5096e22d738d8c0af8a0e8ca1d"
 
 balanced-match@^0.4.1:
   version "0.4.2"
@@ -494,7 +501,7 @@ debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.1, debug@^3.1.0:
+debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -678,9 +678,9 @@ eslint-plugin-import@2.9.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-eslint-plugin-jest@21.15.0:
-  version "21.15.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.15.0.tgz#645a3f560d3e61d99611b215adc80b4f31e6d896"
+eslint-plugin-jest@21.17.0:
+  version "21.17.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.17.0.tgz#fdb00e2f9ff16987d6ebcf2c75c7add105760bbb"
 
 eslint-plugin-react-native-globals@^0.1.1:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -716,9 +716,9 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@4.19.0:
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.0.tgz#9e900efb5506812ac374557034ef6f5c3642fc4c"
+eslint@4.19.1:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"


### PR DESCRIPTION
Upgrade dependencies:

Dev tools:
- prettier 1.13.7
- lint-staged 7.2.0
- npm-run-all 4.1.3
- eslint-find-rules 3.3.1

ESLint and plugins:
- eslint 4.19.1
- eslint-plugin-jest 21.17.0
- eslint-plugin-import 2.13.0
- eslint-plugin-react 7.10.0
- babel-eslint 8.2.5

Configured the following new rules:
- `jest/no-jasmine-globals` as a warning
- `import/no-cycle` as a warning
- `import/no-relative-parent-imports` as off
- `import/dynamic-import-chunkname` as a warning
- `react/jsx-props-no-multi-spaces` as a warning
- `react/no-unsafe` as a warning

**NOTES:**
- eslint 5.x is out, but this only upgrades us to 4.19.1.  We'll do the 5.x upgrade in a separate PR in case we want to release it as a major version bump.

- The new `import/no-cycle` rule is likely to cause some new lint warnings in client projects, but I think it's something we want.  Cyclic dependencies can cause issues with Webpack, so avoiding them is desirable, and if the linter can catch them early, so much the better.  The rule has the potential to be more expensive than normal lint rules, though, so we'll need to keep an eye on linting performance.

Closes #101 
Closes #102 
Closes #104 
