### PR TITLE
✨ Add eslint-plugin-jsx-a11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can override settings from the configuration(s) by adding them directly to y
 We have added some additional optional configurations that you can add on top of the base `zeal` config:
 
 - `zeal/ramda`: Adds rules for [Ramda.js](https://ramdajs.com/) development. You'll need to install [eslint-plugin-ramda](https://github.com/ramda/eslint-plugin-ramda) to use this configuration.
-- `zeal/react`: Adds rules for [React](https://github.com/reactjs) development. You'll need to install [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) to use this configuration.
+- `zeal/react`: Adds rules for [React](https://github.com/reactjs) development. You'll need to install [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) and [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y) to use this configuration.
 - `zeal/react-native`: Adds rules for [React Native](https://facebook.github.io/react-native/) development. You'll need to install [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native) to use this configuration.
 - `zeal/mocha`: Overrides rules for use with [Mocha](https://mochajs.org/). We recommend creating a separate `.eslintrc` file in the directory containing your tests and `extend`ing this config there.
 - `zeal/chai`: Overrides rules for use with [Chai](http://chaijs.com/). We recommend creating a separate `.eslintrc` file in the directory containing your tests and `extend`ing this config there.
@@ -70,10 +70,10 @@ Then, in your `.eslintrc` file, extend both the `zeal` and `zeal/ramda` configur
 
 ## Usage With React
 
-If you're using this package in a React project, make sure you have [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) installed as well:
+If you're using this package in a React project, make sure you have [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) and [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y) installed as well:
 
 ```
-npm install eslint-plugin-react --save-dev
+npm install eslint-plugin-react eslint-plugin-jsx-a11y --save-dev
 ```
 
 Then, in your `.eslintrc` file, extend both the `zeal` and `zeal/react` configurations:
@@ -150,10 +150,11 @@ This plugin contains all of the rules available in:
 
 - [ESLint](http://eslint.org/): 5.6.1
 - [eslint-plugin-ramda](https://github.com/ramda/eslint-plugin-ramda): 2.5.1
-- [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 7.11.1
-- [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native): 3.4.0
 - [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 2.14.0
 - [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest): 21.24.1
+- [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y): 6.1.2
+- [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 7.11.1
+- [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native): 3.4.0
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-find-rules": "^3.3.1",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jest": "21.24.2",
+    "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-ramda": "2.5.1",
     "eslint-plugin-react": "7.11.1",
     "eslint-plugin-react-native": "3.4.0",

--- a/react.js
+++ b/react.js
@@ -4,8 +4,152 @@ module.exports = {
       jsx: true,
     },
   },
-  plugins: ["react"],
+  plugins: ["jsx-a11y", "react"],
   rules: {
+    // Enforce emojis are wrapped in and provide screenreader access.
+    "jsx-a11y/accessible-emoji": "warn",
+    // Enforce all elements that require alternative text have meaningful information to relay back to end user.
+    "jsx-a11y/alt-text": "warn",
+    // Enforce all anchors to contain accessible content.
+    "jsx-a11y/anchor-has-content": "warn",
+    // Enforce all anchors are valid, navigable elements.
+    "jsx-a11y/anchor-is-valid": "warn",
+    // Enforce elements with aria-activedescendant are tabbable.
+    "jsx-a11y/aria-activedescendant-has-tabindex": "warn",
+    // Enforce all aria-* props are valid.
+    "jsx-a11y/aria-props": "warn",
+    // Enforce ARIA state and property values are valid.
+    "jsx-a11y/aria-proptypes": "warn",
+    // Enforce that elements with ARIA roles must use a valid, non-abstract ARIA role.
+    "jsx-a11y/aria-role": "warn",
+    // Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.
+    "jsx-a11y/aria-unsupported-elements": "warn",
+    // Enforce a clickable non-interactive element has at least one keyboard event listener.
+    "jsx-a11y/click-events-have-key-events": "warn",
+    // Enforce heading (h1, h2, etc) elements contain accessible content.
+    "jsx-a11y/heading-has-content": "warn",
+    // Enforce <html> element has lang prop.
+    "jsx-a11y/html-has-lang": "warn",
+    // Enforce iframe elements have a title attribute.
+    "jsx-a11y/iframe-has-title": "warn",
+    // Enforce <img> alt prop does not contain the word "image", "picture", or "photo".
+    "jsx-a11y/img-redundant-alt": "warn",
+    // Enforce that elements with interactive handlers like onClick must be focusable.
+    "jsx-a11y/interactive-supports-focus": [
+      "warn",
+      {
+        tabbable: [
+          "button",
+          "checkbox",
+          "link",
+          "searchbox",
+          "spinbutton",
+          "switch",
+          "textbox",
+        ],
+      },
+    ],
+    // Enforce label tags have an associated control.
+    "jsx-a11y/label-has-associated-control": "warn",
+    // Enforce lang attribute has a valid value.
+    "jsx-a11y/lang": "warn",
+    // Enforces that <audio> and <video> elements must have a <track> for captions.
+    "jsx-a11y/media-has-caption": "warn",
+    // Enforce that onMouseOver/onMouseOut are accompanied by onFocus/onBlur for keyboard-only users.
+    "jsx-a11y/mouse-events-have-key-events": "warn",
+    // Enforce that the accessKey prop is not used on any element to avoid complications with keyboard commands used by a screenreader.
+    "jsx-a11y/no-access-key": "warn",
+    // Enforce autoFocus prop is not used.
+    "jsx-a11y/no-autofocus": "warn",
+    // Enforce distracting elements are not used.
+    "jsx-a11y/no-distracting-elements": "warn",
+    // Interactive elements should not be assigned non-interactive roles.
+    "jsx-a11y/no-interactive-element-to-noninteractive-role": [
+      "warn",
+      {
+        tr: ["none", "presentation"],
+      },
+    ],
+    // Non-interactive elements should not be assigned mouse or keyboard event listeners.
+    "jsx-a11y/no-noninteractive-element-interactions": [
+      "warn",
+      {
+        body: ["onwarn", "onLoad"],
+        handlers: [
+          "onClick",
+          "onwarn",
+          "onLoad",
+          "onMouseDown",
+          "onMouseUp",
+          "onKeyPress",
+          "onKeyDown",
+          "onKeyUp",
+        ],
+        iframe: ["onwarn", "onLoad"],
+        img: ["onwarn", "onLoad"],
+      },
+    ],
+    // Non-interactive elements should not be assigned interactive roles.
+    "jsx-a11y/no-noninteractive-element-to-interactive-role": [
+      "warn",
+      {
+        li: ["menuitem", "option", "row", "tab", "treeitem"],
+        ol: [
+          "listbox",
+          "menu",
+          "menubar",
+          "radiogroup",
+          "tablist",
+          "tree",
+          "treegrid",
+        ],
+        table: ["grid"],
+        td: ["gridcell"],
+        ul: [
+          "listbox",
+          "menu",
+          "menubar",
+          "radiogroup",
+          "tablist",
+          "tree",
+          "treegrid",
+        ],
+      },
+    ],
+    // tabIndex should only be declared on interactive elements.
+    "jsx-a11y/no-noninteractive-tabindex": [
+      "warn",
+      {
+        roles: ["tabpanel"],
+        tags: [],
+      },
+    ],
+    // Enforce usage of onBlur over onChange on select menus for accessibility.
+    "jsx-a11y/no-onchange": "warn",
+    // Enforce explicit role property is not the same as implicit/default role property on element.
+    "jsx-a11y/no-redundant-roles": "warn",
+    // Enforce that non-interactive, visible elements (such as <div>) that have click handlers use the role attribute.
+    "jsx-a11y/no-static-element-interactions": [
+      "warn",
+      {
+        handlers: [
+          "onClick",
+          "onMouseDown",
+          "onMouseUp",
+          "onKeyPress",
+          "onKeyDown",
+          "onKeyUp",
+        ],
+      },
+    ],
+    // Enforce that elements with ARIA roles must have all required attributes for that role.
+    "jsx-a11y/role-has-required-aria-props": "warn",
+    // Enforce that elements with explicit or implicit roles defined contain only aria-* properties supported by that role.
+    "jsx-a11y/role-supports-aria-props": "warn",
+    // Enforce scope prop is only used on <th> elements.
+    "jsx-a11y/scope": "warn",
+    // Enforce tabIndex value is not greater than zero.
+    "jsx-a11y/tabindex-no-positive": "warn",
     // Enforces consistent naming for boolean props
     "react/boolean-prop-naming": "off",
     // Prevent usage of button elements without an explicit type attribute

--- a/yarn.lock
+++ b/yarn.lock
@@ -178,6 +178,14 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
+  integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
+  dependencies:
+    ast-types-flow "0.0.7"
+    commander "^2.11.0"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -243,10 +251,22 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
+ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+  integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
+
 atob@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
   integrity sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=
+
+axobject-query@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.1.tgz#05dfa705ada8ad9db993fa6896f22d395b0b0a07"
+  integrity sha1-Bd+nBa2orZ25k/polvItOVsLCgc=
+  dependencies:
+    ast-types-flow "0.0.7"
 
 babel-eslint@^10.0.1:
   version "10.0.1"
@@ -470,6 +490,11 @@ color-name@^1.1.1:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
+commander@^2.11.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+
 commander@^2.14.1:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
@@ -544,6 +569,11 @@ cross-spawn@^6.0.4, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+damerau-levenshtein@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
+  integrity sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=
 
 date-fns@^1.27.2:
   version "1.29.0"
@@ -666,6 +696,11 @@ elegant-spinner@^1.0.1:
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
+emoji-regex@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
+  integrity sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==
+
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
@@ -763,6 +798,20 @@ eslint-plugin-jest@21.24.2:
   version "21.24.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.24.2.tgz#7a2becb955950a17b037bb2aa857b6deb2f0ab5f"
   integrity sha512-iJJMPR/OqfpQeJcmcBcC/p8/6kXXcwr5K6fkKVpoC8XgLeOtgfJKIs0UxJ7b/tYlTTPT1DnfNKxBtUMmh78R4g==
+
+eslint-plugin-jsx-a11y@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.2.tgz#69bca4890b36dcf0fe16dd2129d2d88b98f33f88"
+  integrity sha512-7gSSmwb3A+fQwtw0arguwMdOdzmKUgnUcbSNlo+GjKLAQFuC2EZxWqG9XHRI8VscBJD5a8raz3RuxQNFW+XJbw==
+  dependencies:
+    aria-query "^3.0.0"
+    array-includes "^3.0.3"
+    ast-types-flow "^0.0.7"
+    axobject-query "^2.0.1"
+    damerau-levenshtein "^1.0.4"
+    emoji-regex "^6.5.1"
+    has "^1.0.3"
+    jsx-ast-utils "^2.0.1"
 
 eslint-plugin-ramda@2.5.1:
   version "2.5.1"


### PR DESCRIPTION
**NOTE:** This is built on top of #115 to avoid merge conflicts.  Please merge that one first.

This adds the jsx-a11y eslint plugin for use in React projects.  The rule configuration is essentially `jsx-a11y/recommended`, but with everything as warnings and not errors, as errors are generally too heavy-handed and keep us from trying something out quickly without worrying about fixing all of the lint warnings right away.

Resolves #107 