### PR TITLE
🔧 Turn off the import/no-unused-modules rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,13 +177,7 @@ module.exports = {
     "import/no-unresolved": ["error", { commonjs: true }],
     // Report modules without exports, or exports without matching import in
     // another module
-    "import/no-unused-modules": [
-      "warn",
-      {
-        missingExports: true,
-        unusedExports: true,
-      },
-    ],
+    "import/no-unused-modules": "off",
     // Ensures that there are no useless path segments
     "import/no-useless-path-segments": "warn",
     // Forbid Webpack loader syntax in imports


### PR DESCRIPTION
After experimenting with `import/no-unused-modules` on a project, we found that it suffers from several issues:

- It is exceedingly slow.  In our test project, linting time increased by 15-20x.  There is an [open issue](https://github.com/benmosher/eslint-plugin-import/issues/1487) about this.  A mitigating PR [has been merged](https://github.com/benmosher/eslint-plugin-import/pull/1449), but not yet released.

- There are too many false postives.  It reports every single Jest test file and [doesn't recognize `module.exports`](https://github.com/benmosher/eslint-plugin-import/issues/1469).

- It doesn't support using globs for ignoring files (see https://github.com/benmosher/eslint-plugin-import/issues/1452 and https://github.com/benmosher/eslint-plugin-import/issues/1326).  If it did, we could more easily tell it to ignore our test files.

Until these issues are resolved upstream, we should keep this rule turned off.