### PR TITLE
⬆️ Upgrade dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This plugin contains all of the rules available in:
 - [eslint-plugin-import-order-alphabetical](https://www.npmjs.com/package/eslint-plugin-import-order-alphabetical): 1.0.0
 - [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest): 22.17.0
 - [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y): 6.2.3
-- [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 7.14.3
+- [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 7.16.0
 - [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks): 2.1.2
 - [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native): 3.7.0
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ This plugin contains all of the rules available in:
 - [ESLint](http://eslint.org/): 6.2.2
 - [eslint-plugin-ramda](https://github.com/ramda/eslint-plugin-ramda): 2.5.1
 - [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 2.18.2
-- [eslint-plugin-import-order-alphabetical](https://www.npmjs.com/package/eslint-plugin-import-order-alphabetical): 0.0.2
+- [eslint-plugin-import-order-alphabetical](https://www.npmjs.com/package/eslint-plugin-import-order-alphabetical): 1.0.0
 - [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest): 22.16.0
 - [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y): 6.2.3
 - [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 7.14.3

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ That way, the `prettier` configurations will override any `zeal` configurations 
 
 This plugin contains all of the rules available in:
 
-- [ESLint](http://eslint.org/): 6.2.2
+- [ESLint](http://eslint.org/): 6.5.1
 - [eslint-plugin-ramda](https://github.com/ramda/eslint-plugin-ramda): 2.5.1
 - [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 2.18.2
 - [eslint-plugin-import-order-alphabetical](https://www.npmjs.com/package/eslint-plugin-import-order-alphabetical): 1.0.0

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ This plugin contains all of the rules available in:
 - [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest): 22.17.0
 - [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y): 6.2.3
 - [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 7.14.3
-- [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks): 2.0.1
+- [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks): 2.1.2
 - [eslint-plugin-react-native](https://github.com/intellicode/eslint-plugin-react-native): 3.7.0
 
 ## License

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ This plugin contains all of the rules available in:
 - [eslint-plugin-ramda](https://github.com/ramda/eslint-plugin-ramda): 2.5.1
 - [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import): 2.18.2
 - [eslint-plugin-import-order-alphabetical](https://www.npmjs.com/package/eslint-plugin-import-order-alphabetical): 1.0.0
-- [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest): 22.16.0
+- [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest): 22.17.0
 - [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y): 6.2.3
 - [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react): 7.14.3
 - [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks): 2.0.1

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
     sourceType: "module",
   },
   plugins: ["import", "import-order-alphabetical"],
+  reportUnusedDisableDirectives: true,
   rules: {
     // Enforces getter/setter pairs in objects
     "accessor-pairs": "warn",
@@ -63,6 +64,8 @@ module.exports = {
     curly: ["warn", "multi-line"],
     // require default case in switch statements
     "default-case": "warn",
+    // enforce default parameters to be last
+    "default-param-last": "warn",
     // enforces consistent newlines before or after dots
     "dot-location": ["warn", "property"],
     // encourages use of dot notation whenever possible
@@ -354,6 +357,8 @@ module.exports = {
     "no-implicit-globals": "warn",
     // disallow use of eval()-like methods
     "no-implied-eval": "warn",
+    // disallow assigning to imported bindings
+    "no-import-assign": "warn",
     // disallow comments inline after code
     "no-inline-comments": "off",
     // disallow function or variable declarations in nested blocks
@@ -601,6 +606,9 @@ module.exports = {
     "prefer-object-spread": "warn",
     // require using Error objects as Promise rejection reasons
     "prefer-promise-reject-errors": "off",
+    //  Disallow use of the RegExp constructor in favor of regular expression
+    //  literals
+    "prefer-regex-literals": "warn",
     // suggest using the rest parameters instead of arguments
     "prefer-rest-params": "warn",
     // suggest using the spread operator instead of .apply().

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-config-prettier": "^6.3.0",
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-import": "2.18.2",
-    "eslint-plugin-import-order-alphabetical": "0.0.2",
+    "eslint-plugin-import-order-alphabetical": "1.0.0",
     "eslint-plugin-jest": "22.16.0",
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-ramda": "2.5.1",
@@ -66,7 +66,7 @@
     "babel-eslint": ">=10.0.3",
     "eslint": ">=6.2.2",
     "eslint-plugin-import": ">=2.18.2",
-    "eslint-plugin-import-order-alphabetical": ">=0.0.2"
+    "eslint-plugin-import-order-alphabetical": ">=1.0.0"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-import-order-alphabetical": "1.0.0",
-    "eslint-plugin-jest": "22.16.0",
+    "eslint-plugin-jest": "22.17.0",
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-ramda": "2.5.1",
     "eslint-plugin-react": "7.14.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-ramda": "2.5.1",
     "eslint-plugin-react": "7.14.3",
-    "eslint-plugin-react-hooks": "2.0.1",
+    "eslint-plugin-react-hooks": "2.1.2",
     "eslint-plugin-react-native": "3.7.0",
     "husky": "^3.0.8",
     "lint-staged": "^9.4.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "devDependencies": {
     "babel-eslint": "^10.0.3",
-    "eslint": "6.2.2",
+    "eslint": "6.5.1",
     "eslint-config-prettier": "^6.3.0",
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-import": "2.18.2",
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "babel-eslint": ">=10.0.3",
-    "eslint": ">=6.2.2",
+    "eslint": ">=6.5.1",
     "eslint-plugin-import": ">=2.18.2",
     "eslint-plugin-import-order-alphabetical": ">=1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-jest": "22.17.0",
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-ramda": "2.5.1",
-    "eslint-plugin-react": "7.14.3",
+    "eslint-plugin-react": "7.16.0",
     "eslint-plugin-react-hooks": "2.1.2",
     "eslint-plugin-react-native": "3.7.0",
     "husky": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "babel-eslint": "^10.0.3",
     "eslint": "6.2.2",
-    "eslint-config-prettier": "^6.1.0",
+    "eslint-config-prettier": "^6.3.0",
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-import-order-alphabetical": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-react-hooks": "2.0.1",
     "eslint-plugin-react-native": "3.7.0",
     "husky": "^3.0.8",
-    "lint-staged": "^9.2.5",
+    "lint-staged": "^9.4.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2"
   },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-react": "7.14.3",
     "eslint-plugin-react-hooks": "2.0.1",
     "eslint-plugin-react-native": "3.7.0",
-    "husky": "^3.0.4",
+    "husky": "^3.0.8",
     "lint-staged": "^9.2.5",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2"

--- a/react.js
+++ b/react.js
@@ -224,6 +224,8 @@ module.exports = {
     "react/jsx-no-target-blank": "warn",
     // Disallow undeclared variables in JSX
     "react/jsx-no-undef": "warn",
+    // Disallow unnecessary fragments
+    "react/jsx-no-useless-fragment": "warn",
     // One JSX Element Per Line
     "react/jsx-one-expression-per-line": ["warn", { allow: "literal" }],
     // Enforce PascalCase for user-defined JSX components

--- a/yarn.lock
+++ b/yarn.lock
@@ -783,10 +783,10 @@ eslint-module-utils@^2.4.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
-eslint-plugin-import-order-alphabetical@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import-order-alphabetical/-/eslint-plugin-import-order-alphabetical-0.0.2.tgz#301e1a7d7cef3790f417d4dceb4b62291ac5ddff"
-  integrity sha512-9WBxC3RzQrJTAJ/epl64k4pvug/Le1OvhydICoQydK/2M4+36lnAlsn/3dsvXR+1WnRuc2mziNTkFUs+tx+22w==
+eslint-plugin-import-order-alphabetical@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import-order-alphabetical/-/eslint-plugin-import-order-alphabetical-1.0.0.tgz#8b568d1a5b719ca38311c31e2f49469cd7d6469d"
+  integrity sha512-BYJvMrLzwuTfAz8dJO0bT1Ok/s78wxGPCDGxp4ZhP7Io/WrD8Z2zdm0httKiFxzshUu+NQhDibF4yXRyskaiLA==
   dependencies:
     eslint-module-utils "^2.2.0"
     lodash "^4.17.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -857,20 +857,20 @@ eslint-plugin-react-native@3.7.0:
   dependencies:
     eslint-plugin-react-native-globals "^0.1.1"
 
-eslint-plugin-react@7.14.3:
-  version "7.14.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz#911030dd7e98ba49e1b2208599571846a66bdf13"
-  integrity sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==
+eslint-plugin-react@7.16.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz#9928e4f3e2122ed3ba6a5b56d0303ba3e41d8c09"
+  integrity sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==
   dependencies:
     array-includes "^3.0.3"
     doctrine "^2.1.0"
     has "^1.0.3"
-    jsx-ast-utils "^2.1.0"
+    jsx-ast-utils "^2.2.1"
     object.entries "^1.1.0"
     object.fromentries "^2.0.0"
     object.values "^1.1.0"
     prop-types "^15.7.2"
-    resolve "^1.10.1"
+    resolve "^1.12.0"
 
 eslint-rule-documentation@^1.0.0:
   version "1.0.20"
@@ -1577,13 +1577,6 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
-
-jsx-ast-utils@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz#0ee4e2c971fb9601c67b5641b71be80faecf0b36"
-  integrity sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==
-  dependencies:
-    array-includes "^3.0.3"
 
 jsx-ast-utils@^2.2.1:
   version "2.2.1"
@@ -2315,7 +2308,7 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve@^1.10.0, resolve@^1.10.1:
+resolve@^1.10.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
   integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1304,10 +1304,10 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
   integrity sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==
 
-husky@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-3.0.4.tgz#10a48ac11ab50859b0939750fa0b4e07ad0bf669"
-  integrity sha512-7Rnt8aJfy+MlV28snmYK7O7vWwtOfeVxV6KhLpUFXlmx5ukQ1nQmNUB7QsAwSgdySB5X+bm7q7JIRgazqBUzKA==
+husky@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-3.0.8.tgz#8de3fed26ce9b43034ef51013c4ad368b6b74ea8"
+  integrity sha512-HFOsgcyrX3qe/rBuqyTt+P4Gxn5P0seJmr215LAZ/vnwK3jWB3r0ck7swbzGRUbufCf9w/lgHPVbF/YXQALgfQ==
   dependencies:
     chalk "^2.4.2"
     cosmiconfig "^5.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,10 +905,10 @@ eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.2.2.tgz#03298280e7750d81fcd31431f3d333e43d93f24f"
-  integrity sha512-mf0elOkxHbdyGX1IJEUsNBzCDdyoUgljF3rRlgfyYh0pwGnreLc0jjD6ZuleOibjmnUWZLY2eXwSooeOgGJ2jw==
+eslint@6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.5.1.tgz#828e4c469697d43bb586144be152198b91e96ed6"
+  integrity sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -739,10 +739,10 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-prettier@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.1.0.tgz#e6f678ba367fbd1273998d5510f76f004e9dce7b"
-  integrity sha512-k9fny9sPjIBQ2ftFTesJV21Rg4R/7a7t7LCtZVrYQiHEp8Nnuk3EGaDmsKSAnsPj0BYcgB2zxzHa2NTkIxcOLg==
+eslint-config-prettier@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.3.0.tgz#e73b48e59dc49d950843f3eb96d519e2248286a3"
+  integrity sha512-EWaGjlDAZRzVFveh2Jsglcere2KK5CJBhkNSa1xs3KfMUGdRiT7lG089eqPdvlzWHpAqaekubOsOMu8W8Yk71A==
   dependencies:
     get-stdin "^6.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -809,10 +809,10 @@ eslint-plugin-import@2.18.2:
     read-pkg-up "^2.0.0"
     resolve "^1.11.0"
 
-eslint-plugin-jest@22.16.0:
-  version "22.16.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.16.0.tgz#30c4e0e9dc331beb2e7369b70dd1363690c1ce05"
-  integrity sha512-eBtSCDhO1k7g3sULX/fuRK+upFQ7s548rrBtxDyM1fSoY7dTWp/wICjrJcDZKVsW7tsFfH22SG+ZaxG5BZodIg==
+eslint-plugin-jest@22.17.0:
+  version "22.17.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.17.0.tgz#dc170ec8369cd1bff9c5dd8589344e3f73c88cf6"
+  integrity sha512-WT4DP4RoGBhIQjv+5D0FM20fAdAUstfYAf/mkufLNTojsfgzc5/IYW22cIg/Q4QBavAZsROQlqppiWDpFZDS8Q==
   dependencies:
     "@typescript-eslint/experimental-utils" "^1.13.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -840,10 +840,10 @@ eslint-plugin-ramda@2.5.1:
     ramda "0.25.0"
     req-all "^1.0.0"
 
-eslint-plugin-react-hooks@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.0.1.tgz#e898ec26a0a335af6f7b0ad1f0bedda7143ed756"
-  integrity sha512-xir+3KHKo86AasxlCV8AHRtIZPHljqCRRUYgASkbatmt0fad4+5GgC7zkT7o/06hdKM6MIwp8giHVXqBPaarHQ==
+eslint-plugin-react-hooks@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.1.2.tgz#1358d2acb2c5e02b7e90c37e611ac258a488e3a7"
+  integrity sha512-ZR+AyesAUGxJAyTFlF3MbzeVHAcQTFQt1fFVe5o0dzY/HFoj1dgQDMoIkiM+ltN/HhlHBYX4JpJwYonjxsyQMA==
 
 eslint-plugin-react-native-globals@^0.1.1:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1608,10 +1608,10 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lint-staged@^9.2.5:
-  version "9.2.5"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-9.2.5.tgz#5a3e1e0a539a403bd7f88542bc3d34ce52efdbb3"
-  integrity sha512-d99gTBFMJ29159+9iRvaMEQstmNcPAbQbhHSYw6D/1FncvFdIj8lWHztaq3Uq+tbZPABHXQ/fyN7Rp1QwF8HIw==
+lint-staged@^9.4.1:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-9.4.1.tgz#60c0f85745bd398e6460aa7f5adb3cad3a2b862c"
+  integrity sha512-zFRbo1bAJEVf1m33paTTjDVfy2v3lICCqHfmQSgNoI+lWpi7HPG5y/R2Y7Whdce+FKxlZYs/U1sDSx8+nmQdDA==
   dependencies:
     chalk "^2.4.2"
     commander "^2.20.0"


### PR DESCRIPTION
Plugins:
- ⬆️ Upgrade to eslint-plugin-import-order-alphabetical 1.0.0
  - Adds eslint 6.x as a peer dependency
  - Closes #155
- ⬆️ Upgrade to eslint-plugin-jest 22.17.0
  - No new rules
  - Closes #154
- ⬆️ Upgrade to eslint-plugin-react-hooks 2.1.2
  - No new rules
  - Closes #156
- ⬆️ Upgrade to eslint-plugin-react 7.16.0
  - New rule: `react/jsx-no-useless-fragment` defaults to `warn`
  - Closes #157
- ⬆️ Upgrade to eslint 6.5.1
  - New configuration setting: `reportUnusedDisableDirectives` set to `true`.  We generally use this in our projects via the command line.  Now we can set it here as a setting.
  - New rule: `no-import-assign` defaults to `warn`.
  - New rule: `prefer-regex-literals` defaults to `warn`.
  - New rule: `default-param-last` defaults to `warn`.
  - Closes #153.

Dev dependencies:
- ⬆️ Upgrade to husky 3.0.8
- ⬆️ Upgrade to lint-staged 9.4.1
- ⬆️ Upgrade to eslint-config-prettier 6.3.0