### PR TITLE
🚨 Remove obsolete eslint disable comments

### DIFF
--- a/chai.js
+++ b/chai.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unused-modules
 module.exports = {
   globals: {
     expect: true,

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unused-modules
 module.exports = {
   env: {
     browser: true,

--- a/jest.js
+++ b/jest.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unused-modules
 module.exports = {
   env: {
     jest: true,

--- a/mocha.js
+++ b/mocha.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unused-modules
 module.exports = {
   env: {
     mocha: true,

--- a/ramda.js
+++ b/ramda.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unused-modules
 module.exports = {
   plugins: ["ramda"],
   rules: {

--- a/react-native.js
+++ b/react-native.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unused-modules
 module.exports = {
   extends: ["plugin:import/react-native"],
   parserOptions: {

--- a/react.js
+++ b/react.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unused-modules
 module.exports = {
   parserOptions: {
     ecmaFeatures: {


### PR DESCRIPTION
In #158, we disabled the `import/no-unused-modules` rule and in #159, enabled the new `reportUnusedDisableDirectives` setting.

However, we had added eslint-disable comments to several files to disable the `import/no-unused-modules` rule for those files.

Those comments are no longer necessary since the rule is disabled, but we didn't catch that when we enabled the new setting in 159.

This PR removes the now-unnecessary comments.

This change is internal-only, and won't affect any users of this package.